### PR TITLE
Adicionei âncoras para seções e módulos na área de membros

### DIFF
--- a/app/Http/Controllers/MemberAreaAppController.php
+++ b/app/Http/Controllers/MemberAreaAppController.php
@@ -90,6 +90,7 @@ class MemberAreaAppController extends Controller
             'sections' => $sections->map(fn (MemberSection $s) => [
                 'id' => $s->id,
                 'title' => $s->title,
+                'anchor' => $s->anchor,
                 'cover_mode' => $s->cover_mode ?? 'vertical',
                 'section_type' => $s->section_type ?? 'courses',
                 'modules' => $s->modules->map(fn ($m) => $this->mapModuleForMemberArea($m, $s, $product, $user, $userProductIds, $baseUrl, $accessStartAt, $now))->values()->all(),
@@ -127,6 +128,7 @@ class MemberAreaAppController extends Controller
             'sections' => $sections->map(fn (MemberSection $s) => [
                 'id' => $s->id,
                 'title' => $s->title,
+                'anchor' => $s->anchor,
                 'cover_mode' => $s->cover_mode ?? 'vertical',
                 'modules' => $s->modules->map(function (MemberModule $m) use ($accessStartAt, $now, $user) {
                     $effective = ($m->source_member_module_id)
@@ -136,6 +138,7 @@ class MemberAreaAppController extends Controller
                     return [
                         'id' => $m->id,
                         'title' => $m->title,
+                        'anchor' => $m->anchor,
                         'thumbnail' => $m->thumbnail,
                         'show_title_on_cover' => $m->show_title_on_cover ?? true,
                         ...$this->moduleLockPayload($effective, $accessStartAt, $now),
@@ -238,10 +241,12 @@ class MemberAreaAppController extends Controller
         $sectionsPayload = $sections->map(fn (MemberSection $s) => [
             'id' => $s->id,
             'title' => $s->title,
+            'anchor' => $s->anchor,
             'cover_mode' => $s->cover_mode ?? 'vertical',
             'modules' => $s->modules->map(fn ($m) => [
                 'id' => $m->id,
                 'title' => $m->title,
+                'anchor' => $m->anchor,
                 'thumbnail' => $m->thumbnail,
                 'show_title_on_cover' => $m->show_title_on_cover ?? true,
                 ...$this->moduleLockPayload($m, $accessStartAt, $now),
@@ -1424,6 +1429,7 @@ class MemberAreaAppController extends Controller
             return [
                 'id' => $m->id,
                 'title' => $m->title,
+                'anchor' => $m->anchor,
                 'thumbnail' => $m->thumbnail,
                 'show_title_on_cover' => $m->show_title_on_cover ?? true,
                 ...$this->moduleLockPayload($m, $accessStartAt, $now),
@@ -1458,6 +1464,7 @@ class MemberAreaAppController extends Controller
             return [
                 'id' => $m->id,
                 'title' => $m->title,
+                'anchor' => $m->anchor,
                 'thumbnail' => $m->thumbnail,
                 'show_title_on_cover' => $m->show_title_on_cover ?? true,
                 'related_product_id' => $m->related_product_id,
@@ -1482,6 +1489,7 @@ class MemberAreaAppController extends Controller
         return [
             'id' => $m->id,
             'title' => $m->title,
+            'anchor' => $m->anchor,
             'thumbnail' => $m->thumbnail,
             'show_title_on_cover' => $m->show_title_on_cover ?? true,
             'external_url' => $m->external_url,

--- a/app/Http/Controllers/MemberBuilderController.php
+++ b/app/Http/Controllers/MemberBuilderController.php
@@ -168,6 +168,7 @@ class MemberBuilderController extends Controller
             'sections' => $produto->memberSections->map(fn (MemberSection $s) => [
                 'id' => $s->id,
                 'title' => $s->title,
+                'anchor' => $s->anchor,
                 'position' => $s->position,
                 'cover_mode' => $s->cover_mode ?? 'vertical',
                 'section_type' => $s->section_type ?? 'courses',
@@ -175,6 +176,7 @@ class MemberBuilderController extends Controller
                     $base = [
                         'id' => $m->id,
                         'title' => $m->title,
+                        'anchor' => $m->anchor,
                         'position' => $m->position,
                         'thumbnail' => $m->thumbnail,
                         'show_title_on_cover' => $m->show_title_on_cover ?? true,
@@ -499,12 +501,64 @@ class MemberBuilderController extends Controller
         return response()->json(['url' => $storage->url($path), 'path' => $path]);
     }
 
+    private function normalizeAnchor(?string $value): ?string
+    {
+        $raw = trim((string) $value);
+        if ($raw === '') {
+            return null;
+        }
+
+        $slug = \Illuminate\Support\Str::slug($raw, '-');
+        $slug = preg_replace('/[^a-z0-9-]+/', '', strtolower($slug)) ?? '';
+        $slug = trim(preg_replace('/-+/', '-', $slug) ?? '', '-');
+
+        return $slug !== '' ? substr($slug, 0, 120) : null;
+    }
+
+    private function resolveUniqueAnchor(Product $produto, ?string $value, ?string $currentType = null, ?int $currentId = null): ?string
+    {
+        $base = $this->normalizeAnchor($value);
+        if ($base === null) {
+            return null;
+        }
+
+        $candidate = $base;
+        $suffix = 2;
+        while ($this->anchorExists($produto, $candidate, $currentType, $currentId)) {
+            $tail = '-' . $suffix;
+            $candidate = substr($base, 0, 120 - strlen($tail)) . $tail;
+            $suffix++;
+        }
+
+        return $candidate;
+    }
+
+    private function anchorExists(Product $produto, string $anchor, ?string $currentType = null, ?int $currentId = null): bool
+    {
+        $sectionExists = MemberSection::query()
+            ->where('product_id', $produto->id)
+            ->where('anchor', $anchor)
+            ->when($currentType === 'section' && $currentId !== null, fn ($query) => $query->where('id', '!=', $currentId))
+            ->exists();
+
+        if ($sectionExists) {
+            return true;
+        }
+
+        return MemberModule::query()
+            ->where('product_id', $produto->id)
+            ->where('anchor', $anchor)
+            ->when($currentType === 'module' && $currentId !== null, fn ($query) => $query->where('id', '!=', $currentId))
+            ->exists();
+    }
+
     // Sections
     public function storeSection(Request $request, Product $produto): JsonResponse|RedirectResponse
     {
         $this->authorizeProduct($produto);
         $validated = $request->validate([
             'title' => ['required', 'string', 'max:255'],
+            'anchor' => ['nullable', 'string', 'max:120'],
             'cover_mode' => ['nullable', 'string', 'in:vertical,horizontal'],
             'section_type' => ['nullable', 'string', 'in:courses,products,external_links'],
         ]);
@@ -512,6 +566,7 @@ class MemberBuilderController extends Controller
         MemberSection::create([
             'product_id' => $produto->id,
             'title' => $validated['title'],
+            'anchor' => $this->resolveUniqueAnchor($produto, $validated['anchor'] ?? null),
             'position' => $max + 1,
             'cover_mode' => $validated['cover_mode'] ?? 'vertical',
             'section_type' => $validated['section_type'] ?? 'courses',
@@ -530,10 +585,14 @@ class MemberBuilderController extends Controller
         }
         $validated = $request->validate([
             'title' => ['sometimes', 'string', 'max:255'],
+            'anchor' => ['nullable', 'string', 'max:120'],
             'position' => ['sometimes', 'integer', 'min:0'],
             'cover_mode' => ['sometimes', 'string', 'in:vertical,horizontal'],
             'section_type' => ['sometimes', 'string', 'in:courses,products,external_links'],
         ]);
+        if (array_key_exists('anchor', $validated)) {
+            $validated['anchor'] = $this->resolveUniqueAnchor($produto, $validated['anchor'], 'section', $section->id);
+        }
         $section->update($validated);
         if ($request->expectsJson()) {
             return response()->json(['message' => 'Seção atualizada.']);
@@ -567,6 +626,7 @@ class MemberBuilderController extends Controller
         if ($sectionType === 'courses') {
             $validated = $request->validate([
                 'title' => ['required', 'string', 'max:255'],
+                'anchor' => ['nullable', 'string', 'max:120'],
                 'show_title_on_cover' => ['nullable', 'boolean'],
                 'release_after_days' => ['nullable', 'integer', 'min:1', 'max:3650'],
                 'release_at_date' => ['nullable', 'date_format:Y-m-d'],
@@ -584,6 +644,7 @@ class MemberBuilderController extends Controller
                 'member_section_id' => $section->id,
                 'product_id' => $produto->id,
                 'title' => $validated['title'],
+                'anchor' => $this->resolveUniqueAnchor($produto, $validated['anchor'] ?? null),
                 'position' => $max + 1,
                 'show_title_on_cover' => $validated['show_title_on_cover'] ?? true,
                 'release_after_days' => $validated['release_after_days'] ?? null,
@@ -592,6 +653,7 @@ class MemberBuilderController extends Controller
         } elseif ($sectionType === 'products') {
             $validated = $request->validate([
                 'title' => ['required', 'string', 'max:255'],
+                'anchor' => ['nullable', 'string', 'max:120'],
                 'related_product_id' => ['required', 'exists:products,id'],
                 'access_type' => ['required', 'string', 'in:paid,free'],
                 'thumbnail' => ['nullable', 'string', 'max:500'],
@@ -633,6 +695,7 @@ class MemberBuilderController extends Controller
                             'member_section_id' => $section->id,
                             'product_id' => $produto->id,
                             'title' => $sourceMod->title !== '' ? $sourceMod->title : $validated['title'],
+                            'anchor' => $this->resolveUniqueAnchor($produto, $validated['anchor'] ?? null),
                             'position' => $position,
                             'related_product_id' => $validated['related_product_id'],
                             'source_member_module_id' => $sourceMod->id,
@@ -659,6 +722,7 @@ class MemberBuilderController extends Controller
                     'member_section_id' => $section->id,
                     'product_id' => $produto->id,
                     'title' => $validated['title'],
+                    'anchor' => $this->resolveUniqueAnchor($produto, $validated['anchor'] ?? null),
                     'position' => $max + 1,
                     'related_product_id' => $validated['related_product_id'],
                     'access_type' => $validated['access_type'],
@@ -671,6 +735,7 @@ class MemberBuilderController extends Controller
             // external_links
             $validated = $request->validate([
                 'title' => ['required', 'string', 'max:255'],
+                'anchor' => ['nullable', 'string', 'max:120'],
                 'external_url' => ['required', 'url', 'max:500'],
                 'thumbnail' => ['nullable', 'string', 'max:500'],
                 'show_title_on_cover' => ['nullable', 'boolean'],
@@ -680,6 +745,7 @@ class MemberBuilderController extends Controller
                 'member_section_id' => $section->id,
                 'product_id' => $produto->id,
                 'title' => $validated['title'],
+                'anchor' => $this->resolveUniqueAnchor($produto, $validated['anchor'] ?? null),
                 'position' => $max + 1,
                 'external_url' => $validated['external_url'],
                 'thumbnail' => $validated['thumbnail'] ?? null,
@@ -712,6 +778,7 @@ class MemberBuilderController extends Controller
         $payload = [
             'id' => $module->id,
             'title' => $module->title,
+            'anchor' => $module->anchor,
             'position' => $module->position,
             'thumbnail' => $module->thumbnail,
             'show_title_on_cover' => $module->show_title_on_cover ?? true,
@@ -759,6 +826,7 @@ class MemberBuilderController extends Controller
         if ($sectionType === 'courses') {
             $validated = $request->validate([
                 'title' => ['sometimes', 'string', 'max:255'],
+                'anchor' => ['nullable', 'string', 'max:120'],
                 'position' => ['sometimes', 'integer', 'min:0'],
                 'thumbnail' => ['nullable', 'string', 'max:500'],
                 'show_title_on_cover' => ['sometimes', 'boolean'],
@@ -782,6 +850,7 @@ class MemberBuilderController extends Controller
         } elseif ($sectionType === 'products') {
             $validated = $request->validate([
                 'title' => ['sometimes', 'string', 'max:255'],
+                'anchor' => ['nullable', 'string', 'max:120'],
                 'position' => ['sometimes', 'integer', 'min:0'],
                 'related_product_id' => ['sometimes', 'exists:products,id'],
                 'access_type' => ['sometimes', 'string', 'in:paid,free'],
@@ -803,11 +872,15 @@ class MemberBuilderController extends Controller
         } else {
             $validated = $request->validate([
                 'title' => ['sometimes', 'string', 'max:255'],
+                'anchor' => ['nullable', 'string', 'max:120'],
                 'position' => ['sometimes', 'integer', 'min:0'],
                 'external_url' => ['sometimes', 'url', 'max:500'],
                 'thumbnail' => ['nullable', 'string', 'max:500'],
                 'show_title_on_cover' => ['sometimes', 'boolean'],
             ]);
+        }
+        if (array_key_exists('anchor', $validated)) {
+            $validated['anchor'] = $this->resolveUniqueAnchor($produto, $validated['anchor'], 'module', $module->id);
         }
         $module->update($validated);
         if ($request->expectsJson()) {

--- a/app/Models/MemberModule.php
+++ b/app/Models/MemberModule.php
@@ -12,6 +12,7 @@ class MemberModule extends Model
         'member_section_id',
         'product_id',
         'title',
+        'anchor',
         'position',
         'thumbnail',
         'show_title_on_cover',

--- a/app/Models/MemberSection.php
+++ b/app/Models/MemberSection.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class MemberSection extends Model
 {
-    protected $fillable = ['product_id', 'title', 'position', 'cover_mode', 'section_type'];
+    protected $fillable = ['product_id', 'title', 'anchor', 'position', 'cover_mode', 'section_type'];
 
     protected function casts(): array
     {

--- a/database/migrations/2026_05_04_000001_add_anchor_to_member_sections_and_modules_tables.php
+++ b/database/migrations/2026_05_04_000001_add_anchor_to_member_sections_and_modules_tables.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('member_sections', function (Blueprint $table) {
+            if (! Schema::hasColumn('member_sections', 'anchor')) {
+                $table->string('anchor', 120)->nullable()->after('title');
+            }
+        });
+
+        Schema::table('member_modules', function (Blueprint $table) {
+            if (! Schema::hasColumn('member_modules', 'anchor')) {
+                $table->string('anchor', 120)->nullable()->after('title');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('member_modules', function (Blueprint $table) {
+            if (Schema::hasColumn('member_modules', 'anchor')) {
+                $table->dropColumn('anchor');
+            }
+        });
+
+        Schema::table('member_sections', function (Blueprint $table) {
+            if (Schema::hasColumn('member_sections', 'anchor')) {
+                $table->dropColumn('anchor');
+            }
+        });
+    }
+};

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -212,4 +212,8 @@
     .lesson-rich-content [data-size='large'] {
         font-size: 1.125em;
     }
+
+    .member-anchor-target {
+        scroll-margin-top: 5rem;
+    }
 }

--- a/resources/js/Layouts/MemberAreaAppLayout.vue
+++ b/resources/js/Layouts/MemberAreaAppLayout.vue
@@ -73,6 +73,42 @@ function closeMobileMenu() {
     mobileMenuOpen.value = false;
 }
 
+function internalMenuHref(item) {
+    const link = String(item?.link || '/').trim() || '/';
+    return link.startsWith('/') ? basePath.value + link : basePath.value + '/' + link;
+}
+
+function samePageAnchorTarget(href) {
+    if (typeof window === 'undefined' || !href) return null;
+    const url = new URL(href, window.location.origin);
+    if (!url.hash) return null;
+
+    const normalizePath = (path) => String(path || '/').replace(/\/+$/, '') || '/';
+    return normalizePath(url.pathname) === normalizePath(window.location.pathname)
+        ? decodeURIComponent(url.hash.slice(1))
+        : null;
+}
+
+function scrollToAnchor(anchor) {
+    if (!anchor) return;
+    const target = document.getElementById(anchor);
+    target?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+}
+
+function handleInternalMenuClick(event, item) {
+    const href = internalMenuHref(item);
+    const anchor = samePageAnchorTarget(href);
+    if (!anchor) {
+        closeMobileMenu();
+        return;
+    }
+
+    event.preventDefault();
+    window.history.pushState({}, '', href);
+    closeMobileMenu();
+    setTimeout(() => scrollToAnchor(anchor), 0);
+}
+
 function onWindowScroll() {
     headerScrolled.value = typeof window !== 'undefined' && window.scrollY > 8;
 }
@@ -505,8 +541,9 @@ watch(
                         </a>
                         <Link
                             v-else
-                            :href="item.link.startsWith('/') ? basePath + item.link : basePath + '/' + item.link"
+                            :href="internalMenuHref(item)"
                             class="rounded-lg px-3 py-2 text-sm font-medium text-white/90 drop-shadow hover:bg-white/10"
+                            @click="handleInternalMenuClick($event, item)"
                         >
                             {{ item.title }}
                         </Link>
@@ -711,9 +748,9 @@ watch(
                             </a>
                             <Link
                                 v-else
-                                :href="item.link.startsWith('/') ? basePath + item.link : basePath + '/' + item.link"
+                                :href="internalMenuHref(item)"
                                 class="rounded-lg px-4 py-3 text-sm font-medium text-zinc-200 hover:bg-zinc-800 hover:text-white"
-                                @click="closeMobileMenu"
+                                @click="handleInternalMenuClick($event, item)"
                             >
                                 {{ item.title }}
                             </Link>

--- a/resources/js/Pages/MemberAreaApp/Modulos.vue
+++ b/resources/js/Pages/MemberAreaApp/Modulos.vue
@@ -16,10 +16,10 @@ const props = defineProps({
     <div class="space-y-8">
         <h1 class="text-2xl font-bold">Módulos</h1>
         <div class="space-y-8">
-            <section v-for="section in sections" :key="section.id" class="space-y-4">
+            <section v-for="section in sections" :id="section.anchor || null" :key="section.id" class="member-anchor-target space-y-4">
                 <h2 class="text-xl font-semibold text-zinc-300">{{ section.title }}</h2>
                 <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                    <div v-for="mod in section.modules" :key="mod.id" class="rounded-xl border border-zinc-700 bg-zinc-800/50 overflow-hidden">
+                    <div v-for="mod in section.modules" :id="mod.anchor || null" :key="mod.id" class="member-anchor-target rounded-xl border border-zinc-700 bg-zinc-800/50 overflow-hidden">
                         <Link v-if="!mod.is_locked" :href="`/m/${slug}/modulo/${mod.id}`" class="block">
                             <div class="aspect-video w-full bg-zinc-700 flex items-center justify-center">
                                 <svg class="h-12 w-12 text-zinc-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>

--- a/resources/js/Pages/MemberAreaApp/Show.vue
+++ b/resources/js/Pages/MemberAreaApp/Show.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref } from 'vue';
+import { nextTick, onMounted, ref } from 'vue';
 import { Link } from '@inertiajs/vue3';
 import { ChevronLeft, ChevronRight, Lock, LockOpen } from 'lucide-vue-next';
 import MemberAreaAppLayout from '@/Layouts/MemberAreaAppLayout.vue';
@@ -68,6 +68,21 @@ function productSectionNeedsCheckout(mod) {
 function productSectionUnlocked(mod) {
     return !productSectionNeedsCheckout(mod);
 }
+
+function scrollToHashAnchor() {
+    if (typeof window === 'undefined' || !window.location.hash) return;
+    const anchor = decodeURIComponent(window.location.hash.slice(1));
+    if (!anchor) return;
+
+    nextTick(() => {
+        setTimeout(() => {
+            const target = document.getElementById(anchor);
+            target?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }, 50);
+    });
+}
+
+onMounted(scrollToHashAnchor);
 
 </script>
 
@@ -160,7 +175,7 @@ function productSectionUnlocked(mod) {
         </section>
 
         <!-- Módulos por seção (conteúdo conforme tipo: cursos, outros produtos, links externos) -->
-        <section v-for="section in sections" :key="section.id" class="space-y-4">
+        <section v-for="section in sections" :id="section.anchor || null" :key="section.id" class="member-anchor-target space-y-4">
             <div class="flex items-center justify-between gap-2">
                 <h2 class="text-xl font-semibold">{{ section.title }}</h2>
                 <div v-if="carouselHasOverflow[section.id]" class="flex shrink-0 items-center gap-1">
@@ -191,8 +206,9 @@ function productSectionUnlocked(mod) {
                     <template v-for="mod in section.modules" :key="mod.id">
                         <Link
                             v-if="!mod.is_locked"
+                            :id="mod.anchor || null"
                             :href="`/m/${slug}/modulo/${mod.id}`"
-                            class="flex w-64 shrink-0 flex-col rounded-xl overflow-hidden bg-zinc-800/50 text-left transition hover:bg-zinc-800"
+                            class="member-anchor-target flex w-64 shrink-0 flex-col rounded-xl overflow-hidden bg-zinc-800/50 text-left transition hover:bg-zinc-800"
                         >
                             <div :class="[(section.cover_mode === 'horizontal' ? 'aspect-video' : 'aspect-[2/3]'), 'relative w-full bg-zinc-700 flex items-center justify-center overflow-hidden']">
                                 <img v-if="mod.thumbnail" :src="mod.thumbnail" :alt="mod.title" class="absolute inset-0 h-full w-full object-cover" />
@@ -204,7 +220,8 @@ function productSectionUnlocked(mod) {
                         </Link>
                         <div
                             v-else
-                            class="flex w-64 shrink-0 cursor-not-allowed flex-col rounded-xl overflow-hidden bg-zinc-800/30 text-left opacity-70"
+                            :id="mod.anchor || null"
+                            class="member-anchor-target flex w-64 shrink-0 cursor-not-allowed flex-col rounded-xl overflow-hidden bg-zinc-800/30 text-left opacity-70"
                         >
                             <div :class="[(section.cover_mode === 'horizontal' ? 'aspect-video' : 'aspect-[2/3]'), 'relative w-full bg-zinc-700 flex items-center justify-center overflow-hidden']">
                                 <img v-if="mod.thumbnail" :src="mod.thumbnail" :alt="mod.title" class="absolute inset-0 h-full w-full object-cover" />
@@ -222,6 +239,7 @@ function productSectionUnlocked(mod) {
                 <template v-else-if="(section.section_type ?? 'courses') === 'products'">
                     <component
                         v-for="mod in section.modules"
+                        :id="mod.anchor || null"
                         :key="mod.id"
                         :is="(productSectionNeedsCheckout(mod) || (mod.related_product?.type === 'link')) ? 'a' : Link"
                         :href="productSectionNeedsCheckout(mod)
@@ -231,7 +249,7 @@ function productSectionUnlocked(mod) {
                                 : (mod.embed ? `${base_url}/modulo/${mod.id}` : `${base_url}/products/${mod.related_product?.id}/open`))"
                         :target="(productSectionNeedsCheckout(mod) || (mod.related_product?.type === 'link')) ? '_blank' : undefined"
                         :rel="(productSectionNeedsCheckout(mod) || (mod.related_product?.type === 'link')) ? 'noopener' : undefined"
-                        class="flex w-64 shrink-0 flex-col rounded-xl overflow-hidden bg-zinc-800/50 text-left transition hover:bg-zinc-800"
+                        class="member-anchor-target flex w-64 shrink-0 flex-col rounded-xl overflow-hidden bg-zinc-800/50 text-left transition hover:bg-zinc-800"
                     >
                         <div :class="[(section.cover_mode === 'horizontal' ? 'aspect-video' : 'aspect-[2/3]'), 'relative w-full bg-zinc-700 flex items-center justify-center overflow-hidden']">
                             <div
@@ -258,11 +276,12 @@ function productSectionUnlocked(mod) {
                 <template v-else>
                     <a
                         v-for="mod in section.modules"
+                        :id="mod.anchor || null"
                         :key="mod.id"
                         :href="mod.external_url"
                         target="_blank"
                         rel="noopener"
-                        class="flex w-64 shrink-0 flex-col rounded-xl overflow-hidden bg-zinc-800/50 text-left transition hover:bg-zinc-800"
+                        class="member-anchor-target flex w-64 shrink-0 flex-col rounded-xl overflow-hidden bg-zinc-800/50 text-left transition hover:bg-zinc-800"
                     >
                         <div :class="[(section.cover_mode === 'horizontal' ? 'aspect-video' : 'aspect-[2/3]'), 'relative w-full bg-zinc-700 flex items-center justify-center overflow-hidden']">
                             <img v-if="mod.thumbnail" :src="mod.thumbnail" :alt="mod.title" class="absolute inset-0 h-full w-full object-cover" />

--- a/resources/js/Pages/Produtos/Edit.vue
+++ b/resources/js/Pages/Produtos/Edit.vue
@@ -1187,100 +1187,104 @@ const typeIcons = {
     link_pagamento: CreditCard,
 };
 
+function buildCartRecoveryPayload() {
+    const cre = form.cart_recovery_email && typeof form.cart_recovery_email === 'object' ? form.cart_recovery_email : {};
+    const creStages = cre?.stages && typeof cre.stages === 'object' ? cre.stages : {};
+
+    return {
+        enabled: !!cre.enabled,
+        stages: {
+            '10m': {
+                subject: String(creStages?.['10m']?.subject ?? ''),
+                body_text: String(creStages?.['10m']?.body_text ?? ''),
+                body_html: '',
+            },
+            '5h': {
+                subject: String(creStages?.['5h']?.subject ?? ''),
+                body_text: String(creStages?.['5h']?.body_text ?? ''),
+                body_html: '',
+            },
+            '24h': {
+                subject: String(creStages?.['24h']?.subject ?? ''),
+                body_text: String(creStages?.['24h']?.body_text ?? ''),
+                body_html: '',
+            },
+        },
+    };
+}
+
+function buildProductPayload() {
+    const companyAddress = form.pagarme_billing?.company_address || {};
+    const payload = {
+        name: form.name,
+        slug: form.slug,
+        description: form.description ?? '',
+        type: form.type,
+        billing_type: form.billing_type,
+        price: form.price,
+        combo_product_ids: Array.isArray(form.combo_product_ids) ? [...form.combo_product_ids] : [],
+        currency: form.currency,
+        is_active: !!form.is_active,
+        conversion_pixels: form.conversion_pixels,
+        cart_recovery_email: buildCartRecoveryPayload(),
+        payment_gateways: form.payment_gateways,
+        card_installments: form.card_installments
+            ? {
+                  enabled: !!form.card_installments.enabled,
+                  max: Math.min(12, Math.max(1, form.card_installments.max || 1)),
+              }
+            : null,
+        stripe_link_enabled: !!form.stripe_link_enabled,
+        email_template: {
+            logo_url: form.email_template?.logo_url || '',
+            from_name: form.email_template?.from_name || '',
+            subject: form.email_template?.subject || '',
+            body_text: form.email_template?.body_text || '',
+            body_html: '',
+        },
+        deliverable_link: form.deliverable_link || '',
+        pagarme_billing: {
+            mode: form.pagarme_billing?.mode || 'customer',
+            company_address: {
+                zipcode: companyAddress.zipcode || '',
+                street: companyAddress.street || '',
+                number: companyAddress.number || '',
+                neighborhood: companyAddress.neighborhood || '',
+                city: companyAddress.city || '',
+                state: String(companyAddress.state || '').slice(0, 2),
+            },
+        },
+    };
+
+    if (form.billing_type === 'subscription') {
+        payload.base_interval = form.base_interval || 'monthly';
+    }
+
+    return payload;
+}
+
 function submit() {
     const baseUrl = `/produtos/${props.produto.id}`;
     const tab = currentTab.value && currentTab.value !== 'geral' ? `?tab=${currentTab.value}` : '';
     const url = baseUrl + tab;
-    if (form.image) {
-        const fd = new FormData();
-        fd.append('name', form.name);
-        fd.append('slug', form.slug);
-        fd.append('description', form.description);
-        fd.append('type', form.type);
-        fd.append('billing_type', form.billing_type);
-        fd.append('price', form.price);
-        (form.combo_product_ids || []).forEach((id) => fd.append('combo_product_ids[]', id));
-        if (form.billing_type === 'subscription') {
-            fd.append('base_interval', form.base_interval || 'monthly');
-        }
-        fd.append('currency', form.currency);
-        fd.append('is_active', form.is_active ? '1' : '0');
-        fd.append('conversion_pixels', JSON.stringify(form.conversion_pixels));
-        // Envia texto simples; o backend monta o HTML bonito automaticamente.
-        const cre = form.cart_recovery_email && typeof form.cart_recovery_email === 'object' ? form.cart_recovery_email : {};
-        const creStages = cre?.stages && typeof cre.stages === 'object' ? cre.stages : {};
-        const crePayload = {
-            enabled: !!cre.enabled,
-            stages: {
-                '10m': {
-                    subject: String(creStages?.['10m']?.subject ?? ''),
-                    body_text: String(creStages?.['10m']?.body_text ?? ''),
-                    body_html: '',
-                },
-                '5h': {
-                    subject: String(creStages?.['5h']?.subject ?? ''),
-                    body_text: String(creStages?.['5h']?.body_text ?? ''),
-                    body_html: '',
-                },
-                '24h': {
-                    subject: String(creStages?.['24h']?.subject ?? ''),
-                    body_text: String(creStages?.['24h']?.body_text ?? ''),
-                    body_html: '',
-                },
+    const payload = buildProductPayload();
+
+    if (form.image instanceof File) {
+        form.transform(() => ({
+            ...payload,
+            _method: 'PUT',
+            image: form.image,
+        })).post(url, {
+            forceFormData: true,
+            preserveScroll: true,
+            onSuccess: () => {
+                form.image = null;
             },
-        };
-        fd.append('cart_recovery_email', JSON.stringify(crePayload));
-        if (form.payment_gateways) {
-            fd.append('payment_gateways[pix]', form.payment_gateways.pix || '');
-            (form.payment_gateways.pix_redundancy || []).forEach((s) => fd.append('payment_gateways[pix_redundancy][]', s));
-            fd.append('payment_gateways[card]', form.payment_gateways.card || '');
-            (form.payment_gateways.card_redundancy || []).forEach((s) => fd.append('payment_gateways[card_redundancy][]', s));
-            fd.append('payment_gateways[boleto]', form.payment_gateways.boleto || '');
-            (form.payment_gateways.boleto_redundancy || []).forEach((s) => fd.append('payment_gateways[boleto_redundancy][]', s));
-            fd.append('payment_gateways[crypto]', form.payment_gateways.crypto || '');
-            (form.payment_gateways.crypto_redundancy || []).forEach((s) => fd.append('payment_gateways[crypto_redundancy][]', s));
-            if (form.billing_type === 'subscription') {
-                fd.append('payment_gateways[pix_auto]', form.payment_gateways.pix_auto || '');
-                (form.payment_gateways.pix_auto_redundancy || []).forEach((s) => fd.append('payment_gateways[pix_auto_redundancy][]', s));
-            }
-        }
-        if (form.card_installments) {
-            fd.append('card_installments[enabled]', form.card_installments.enabled ? '1' : '0');
-            fd.append('card_installments[max]', String(Math.min(12, Math.max(1, form.card_installments.max || 1))));
-        }
-        if (typeof form.stripe_link_enabled === 'boolean') {
-            fd.append('stripe_link_enabled', form.stripe_link_enabled ? '1' : '0');
-        }
-        if (form.email_template) {
-            fd.append('email_template[logo_url]', form.email_template.logo_url || '');
-            fd.append('email_template[from_name]', form.email_template.from_name || '');
-            fd.append('email_template[subject]', form.email_template.subject || '');
-            fd.append('email_template[body_text]', form.email_template.body_text || '');
-            // Mantém compatibilidade mas evita o usuário ter que digitar HTML.
-            fd.append('email_template[body_html]', '');
-        }
-        fd.append('deliverable_link', form.deliverable_link || '');
-        if (form.pagarme_billing) {
-            fd.append('pagarme_billing[mode]', form.pagarme_billing.mode || 'customer');
-            const ca = form.pagarme_billing.company_address || {};
-            fd.append('pagarme_billing[company_address][zipcode]', ca.zipcode || '');
-            fd.append('pagarme_billing[company_address][street]', ca.street || '');
-            fd.append('pagarme_billing[company_address][number]', ca.number || '');
-            fd.append('pagarme_billing[company_address][neighborhood]', ca.neighborhood || '');
-            fd.append('pagarme_billing[company_address][city]', ca.city || '');
-            fd.append('pagarme_billing[company_address][state]', String(ca.state || '').slice(0, 2));
-        }
-        fd.append('_method', 'PUT');
-        fd.append('image', form.image);
-        form.transform(() => fd).post(url, { forceFormData: true });
-    } else {
-        form.transform((data) => {
-            if (data.billing_type === 'subscription') {
-                data.base_interval = data.base_interval || 'monthly';
-            }
-            return data;
-        }).put(url);
+        });
+        return;
     }
+
+    form.transform(() => payload).put(url, { preserveScroll: true });
 }
 </script>
 

--- a/resources/js/Pages/Produtos/MemberBuilder/Standalone.vue
+++ b/resources/js/Pages/Produtos/MemberBuilder/Standalone.vue
@@ -3,6 +3,7 @@ import { ref, computed, reactive, nextTick, onMounted, watch } from 'vue';
 import axios from 'axios';
 import MemberBuilderPreview from '@/components/member-builder/MemberBuilderPreview.vue';
 import RichTextEditor from '@/components/member-builder/RichTextEditor.vue';
+import { normalizeAnchorSlug } from '@/lib/utils';
 import Button from '@/components/ui/Button.vue';
 import Toggle from '@/components/ui/Toggle.vue';
 import {
@@ -746,8 +747,10 @@ function cancelEdit() {
 }
 
 const editingSectionTitle = ref('');
+const editingSectionAnchor = ref('');
 const editingSectionCoverMode = ref('vertical');
 const editingModuleTitle = ref('');
+const editingModuleAnchor = ref('');
 const editingModuleShowTitleOnCover = ref(true);
 const editingModuleRelatedProductId = ref(null);
 const editingModuleAccessType = ref('paid');
@@ -758,6 +761,7 @@ const editingModuleReleaseAtDate = ref('');
 
 const sectionModalOpen = ref(false);
 const sectionModalTitle = ref('');
+const sectionModalAnchor = ref('');
 const sectionModalCoverMode = ref('vertical');
 const sectionModalSectionType = ref('courses');
 const sectionModalSaving = ref(false);
@@ -767,6 +771,7 @@ const moduleModalSectionId = ref(null);
 const moduleModalSectionType = ref('courses'); // courses | products | external_links
 const moduleModalCoverMode = ref('vertical'); // modo da seção: vertical | horizontal
 const moduleModalTitle = ref('');
+const moduleModalAnchor = ref('');
 const moduleModalShowTitleOnCover = ref(true);
 const moduleModalFile = ref(null);
 const moduleModalFilePreviewUrl = ref('');
@@ -781,6 +786,7 @@ const moduleModalReleaseAtDate = ref('');
 
 function openSectionEdit(section) {
     editingSectionTitle.value = section.title;
+    editingSectionAnchor.value = section.anchor ?? '';
     editingSectionCoverMode.value = section.cover_mode ?? 'vertical';
     startEditSection(section.id);
 }
@@ -788,9 +794,11 @@ function openSectionEdit(section) {
 async function saveSectionTitle() {
     const id = editingSectionId.value;
     if (!id) return;
+    editingSectionAnchor.value = normalizeAnchorSlug(editingSectionAnchor.value);
     try {
         await axios.put(`${base.value}/sections/${id}`, {
             title: editingSectionTitle.value,
+            anchor: editingSectionAnchor.value,
             cover_mode: editingSectionCoverMode.value,
         }, { headers: headers() });
         cancelEdit();
@@ -800,6 +808,7 @@ async function saveSectionTitle() {
 
 function openModuleEdit(mod) {
     editingModuleTitle.value = mod.title;
+    editingModuleAnchor.value = mod.anchor ?? '';
     editingModuleShowTitleOnCover.value = mod.show_title_on_cover !== false;
     editingModuleRelatedProductId.value = mod.related_product_id ?? null;
     editingModuleAccessType.value = mod.access_type ?? 'paid';
@@ -826,7 +835,8 @@ async function saveModuleTitle() {
     const mod = editingModule.value;
     const section = props.produto.sections?.find((s) => s.modules?.some((m) => m.id === id));
     const sectionType = section?.section_type ?? 'courses';
-    const payload = { title: editingModuleTitle.value };
+    editingModuleAnchor.value = normalizeAnchorSlug(editingModuleAnchor.value);
+    const payload = { title: editingModuleTitle.value, anchor: editingModuleAnchor.value };
     if (sectionType === 'courses') {
         payload.show_title_on_cover = editingModuleShowTitleOnCover.value;
         if (editingModuleReleaseMode.value === 'days') {
@@ -1194,6 +1204,7 @@ function sectionTypeLabel(sectionType) {
 
 function openSectionModal() {
     sectionModalTitle.value = '';
+    sectionModalAnchor.value = '';
     sectionModalCoverMode.value = 'vertical';
     sectionModalSectionType.value = 'courses';
     sectionModalOpen.value = true;
@@ -1206,10 +1217,12 @@ function closeSectionModal() {
 async function confirmNewSection() {
     const title = sectionModalTitle.value?.trim();
     if (!title) return;
+    sectionModalAnchor.value = normalizeAnchorSlug(sectionModalAnchor.value);
     sectionModalSaving.value = true;
     try {
         await axios.post(`${base.value}/sections`, {
             title,
+            anchor: sectionModalAnchor.value,
             cover_mode: sectionModalCoverMode.value,
             section_type: sectionModalSectionType.value,
         }, { headers: headers() });
@@ -1237,6 +1250,7 @@ function openModuleModal(sectionId) {
     moduleModalSectionType.value = section?.section_type ?? 'courses';
     moduleModalCoverMode.value = section?.cover_mode ?? 'vertical';
     moduleModalTitle.value = '';
+    moduleModalAnchor.value = '';
     moduleModalShowTitleOnCover.value = true;
     moduleModalRelatedProductId.value = null;
     moduleModalAccessType.value = 'paid';
@@ -1277,9 +1291,10 @@ async function confirmNewModule() {
     const sectionType = moduleModalSectionType.value;
     if (sectionType === 'products' && !moduleModalRelatedProductId.value) return;
     if (sectionType === 'external_links' && !moduleModalExternalUrl.value?.trim()) return;
+    moduleModalAnchor.value = normalizeAnchorSlug(moduleModalAnchor.value);
     moduleModalSaving.value = true;
     try {
-        let payload = { title };
+        let payload = { title, anchor: moduleModalAnchor.value };
         if (sectionType === 'courses') {
             payload.show_title_on_cover = moduleModalShowTitleOnCover.value;
             if (moduleModalReleaseMode.value === 'days') {
@@ -1875,7 +1890,7 @@ const inputClass = 'block w-full rounded-lg border border-zinc-300 bg-white px-3
 
                     <template v-else-if="activeTab === 'header'">
                         <h2 class="mb-4 text-sm font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">Menus do header</h2>
-                        <p class="mb-4 text-xs text-zinc-500 dark:text-zinc-400">Itens exibidos no header da área de membros, ao lado da logo. O link pode ser interno (ex: /modulos) ou externo (marque "Abrir em nova aba").</p>
+                        <p class="mb-4 text-xs text-zinc-500 dark:text-zinc-400">Itens exibidos no header da área de membros, ao lado da logo. O link pode ser interno (ex: /modulos), âncora (ex: /#introducao) ou externo (marque "Abrir em nova aba").</p>
                         <div class="space-y-4">
                             <div
                                 v-for="(item, index) in headerItems"
@@ -1895,8 +1910,8 @@ const inputClass = 'block w-full rounded-lg border border-zinc-300 bg-white px-3
                                     </div>
                                     <div>
                                         <label class="mb-0.5 block text-xs font-medium text-zinc-600 dark:text-zinc-400">Link</label>
-                                        <input v-model="item.link" type="text" :class="inputClass" placeholder="Ex: / ou /modulos ou https://..." />
-                                        <p class="mt-0.5 text-xs text-zinc-500 dark:text-zinc-400">Interno: use / ou /modulos. Externo: URL completa.</p>
+                                        <input v-model="item.link" type="text" :class="inputClass" placeholder="Ex: /, /modulos, /#introducao ou https://..." />
+                                        <p class="mt-0.5 text-xs text-zinc-500 dark:text-zinc-400">Interno: use / ou /modulos. Âncora: use /#introducao. Externo: URL completa.</p>
                                     </div>
                                     <div class="flex items-center gap-2">
                                         <input
@@ -2024,6 +2039,11 @@ const inputClass = 'block w-full rounded-lg border border-zinc-300 bg-white px-3
                                             <!-- Conteúdo: edição ou visualização -->
                                             <template v-if="editingSectionId === section.id">
                                                 <input v-model="editingSectionTitle" type="text" :class="inputClass" class="!py-1.5 !text-sm min-w-0 w-full" placeholder="Título da seção" @keydown.enter="saveSectionTitle" @keydown.escape="cancelEdit" />
+                                                <div>
+                                                    <label class="mb-0.5 block text-xs font-medium text-zinc-600 dark:text-zinc-400">Âncora da seção</label>
+                                                    <input v-model="editingSectionAnchor" type="text" :class="inputClass" class="!py-1.5 !text-sm min-w-0 w-full font-mono" placeholder="introducao" @blur="editingSectionAnchor = normalizeAnchorSlug(editingSectionAnchor)" @keydown.enter="saveSectionTitle" @keydown.escape="cancelEdit" />
+                                                    <p class="mt-0.5 text-[11px] text-zinc-500 dark:text-zinc-400">Opcional. Use no Header como /#{{ editingSectionAnchor || 'introducao' }}.</p>
+                                                </div>
                                                 <div class="space-y-1.5">
                                                     <span class="block text-xs font-medium text-zinc-600 dark:text-zinc-400">Modo de capa dos módulos</span>
                                                     <div class="flex flex-wrap items-center gap-2">
@@ -2061,6 +2081,7 @@ const inputClass = 'block w-full rounded-lg border border-zinc-300 bg-white px-3
                                             <template v-else>
                                                 <div class="flex min-w-0 items-center justify-between gap-2">
                                                     <span class="min-w-0 truncate cursor-pointer text-sm font-medium text-zinc-800 dark:text-zinc-200" @click="toggleSection(section.id)">{{ section.title }}</span>
+                                                    <span v-if="section.anchor" class="hidden shrink-0 rounded bg-sky-50 px-1.5 py-0.5 font-mono text-[10px] text-sky-700 dark:bg-sky-950/40 dark:text-sky-300 sm:inline">#{{ section.anchor }}</span>
                                                     <div class="flex shrink-0 items-center gap-1">
                                                         <button type="button" class="rounded p-1.5 text-zinc-500 hover:bg-zinc-100 hover:text-zinc-700 dark:hover:bg-zinc-700 dark:hover:text-zinc-300" title="Editar seção" @click.stop="openSectionEdit(section)"><Pencil class="h-3.5 w-3.5" /></button>
                                                         <Button size="sm" variant="outline" class="!py-1 !text-xs" @click.stop="openModuleModal(section.id)">+ Módulo</Button>
@@ -2089,6 +2110,7 @@ const inputClass = 'block w-full rounded-lg border border-zinc-300 bg-white px-3
                                                         </div>
                                                         <div class="min-w-0 flex-1 p-1.5">
                                                             <p class="truncate text-xs font-medium text-zinc-800 dark:text-zinc-200">{{ mod.title }}</p>
+                                                            <p v-if="mod.anchor" class="truncate font-mono text-[10px] text-sky-600 dark:text-sky-300">#{{ mod.anchor }}</p>
                                                             <p class="text-[10px] text-zinc-500 dark:text-zinc-400">{{ (mod.lessons?.length ?? 0) }} {{ (mod.lessons?.length ?? 0) === 1 ? 'aula' : 'aulas' }}</p>
                                                         </div>
                                                     </button>
@@ -2113,6 +2135,11 @@ const inputClass = 'block w-full rounded-lg border border-zinc-300 bg-white px-3
                                                     </div>
                                                     <div class="mb-3">
                                                         <input v-model="editingModuleTitle" type="text" :class="inputClass" class="!py-1.5 !text-sm w-full" placeholder="Título do módulo" @keydown.enter="saveModuleTitle" @keydown.escape="cancelEdit" />
+                                                    </div>
+                                                    <div class="mb-3">
+                                                        <label class="mb-0.5 block text-xs font-medium text-zinc-600 dark:text-zinc-400">Âncora do módulo</label>
+                                                        <input v-model="editingModuleAnchor" type="text" :class="inputClass" class="!py-1.5 !text-sm w-full font-mono" placeholder="modulo-1" @blur="editingModuleAnchor = normalizeAnchorSlug(editingModuleAnchor)" @keydown.enter="saveModuleTitle" @keydown.escape="cancelEdit" />
+                                                        <p class="mt-0.5 text-[11px] text-zinc-500 dark:text-zinc-400">Opcional. Use no Header como /#{{ editingModuleAnchor || 'modulo-1' }}.</p>
                                                     </div>
                                                     <div class="mb-3">
                                                         <label class="mb-1 block text-xs font-medium text-zinc-600 dark:text-zinc-400">Liberação</label>
@@ -2175,6 +2202,7 @@ const inputClass = 'block w-full rounded-lg border border-zinc-300 bg-white px-3
                                                         <template v-if="editingModuleId === mod.id">
                                                             <div class="flex min-w-0 flex-1 flex-col gap-2">
                                                                 <input v-model="editingModuleTitle" type="text" :class="inputClass" class="!py-1.5 !text-xs min-w-0 w-full" placeholder="Título" @keydown.enter="saveModuleTitle" @keydown.escape="cancelEdit" />
+                                                                <input v-model="editingModuleAnchor" type="text" :class="inputClass" class="!py-1.5 !text-xs min-w-0 w-full font-mono" placeholder="Âncora: produto-extra" @blur="editingModuleAnchor = normalizeAnchorSlug(editingModuleAnchor)" @keydown.enter="saveModuleTitle" @keydown.escape="cancelEdit" />
                                                                 <select v-model="editingModuleRelatedProductId" :class="inputClass" class="!py-1.5 !text-xs min-w-0 w-full">
                                                                     <option :value="null">Selecione o produto</option>
                                                                     <option v-for="p in tenant_products" :key="p.id" :value="p.id">{{ p.name }}</option>
@@ -2191,6 +2219,7 @@ const inputClass = 'block w-full rounded-lg border border-zinc-300 bg-white px-3
                                                         </template>
                                                         <template v-else>
                                                             <span class="min-w-0 flex-1 truncate text-xs font-medium text-zinc-700 dark:text-zinc-300">{{ mod.title }}</span>
+                                                            <span v-if="mod.anchor" class="hidden shrink-0 rounded bg-sky-50 px-1.5 py-0.5 font-mono text-[10px] text-sky-700 dark:bg-sky-950/40 dark:text-sky-300 sm:inline">#{{ mod.anchor }}</span>
                                                             <span class="shrink-0 truncate text-xs text-zinc-500 dark:text-zinc-400" :title="mod.related_product?.name">{{ mod.related_product?.name ?? '#' + mod.related_product_id }}</span>
                                                             <span class="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium" :class="mod.access_type === 'free' ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300' : 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300'">{{ mod.access_type === 'free' ? 'Liberado' : 'Pago' }}</span>
                                                             <div class="flex shrink-0 items-center gap-0.5">
@@ -2240,6 +2269,7 @@ const inputClass = 'block w-full rounded-lg border border-zinc-300 bg-white px-3
                                                         <template v-if="editingModuleId === mod.id">
                                                             <div class="flex min-w-0 flex-1 flex-col gap-2">
                                                                 <input v-model="editingModuleTitle" type="text" :class="inputClass" class="!py-1.5 !text-xs min-w-0 w-full" placeholder="Título" @keydown.enter="saveModuleTitle" @keydown.escape="cancelEdit" />
+                                                                <input v-model="editingModuleAnchor" type="text" :class="inputClass" class="!py-1.5 !text-xs min-w-0 w-full font-mono" placeholder="Âncora: link-extra" @blur="editingModuleAnchor = normalizeAnchorSlug(editingModuleAnchor)" @keydown.enter="saveModuleTitle" @keydown.escape="cancelEdit" />
                                                                 <input v-model="editingModuleExternalUrl" type="url" :class="inputClass" class="!py-1.5 !text-xs min-w-0 w-full" placeholder="https://..." />
                                                                 <div class="flex flex-wrap items-center gap-2">
                                                                     <Button size="sm" class="!py-0.5 !text-xs shrink-0" @click="saveModuleTitle">Ok</Button>
@@ -2249,6 +2279,7 @@ const inputClass = 'block w-full rounded-lg border border-zinc-300 bg-white px-3
                                                         </template>
                                                         <template v-else>
                                                             <span class="min-w-0 flex-1 truncate text-xs font-medium text-zinc-700 dark:text-zinc-300">{{ mod.title }}</span>
+                                                            <span v-if="mod.anchor" class="hidden shrink-0 rounded bg-sky-50 px-1.5 py-0.5 font-mono text-[10px] text-sky-700 dark:bg-sky-950/40 dark:text-sky-300 sm:inline">#{{ mod.anchor }}</span>
                                                             <a :href="mod.external_url" target="_blank" rel="noopener" class="min-w-0 max-w-[50%] truncate text-xs text-sky-600 hover:underline dark:text-sky-400" :title="mod.external_url">{{ mod.external_url }}</a>
                                                             <div class="flex shrink-0 items-center gap-0.5">
                                                                 <button type="button" class="rounded p-1 text-zinc-500 hover:bg-zinc-100 dark:hover:bg-zinc-700" title="Editar" @click.stop="openModuleEdit(mod)"><Pencil class="h-3 w-3" /></button>
@@ -3241,6 +3272,11 @@ const inputClass = 'block w-full rounded-lg border border-zinc-300 bg-white px-3
                             <input v-model="sectionModalTitle" type="text" :class="inputClass" placeholder="Título da seção" class="w-full" />
                         </div>
                         <div>
+                            <label class="mb-1 block text-sm font-medium text-zinc-700 dark:text-zinc-300">Âncora da seção</label>
+                            <input v-model="sectionModalAnchor" type="text" :class="inputClass" placeholder="introducao" class="w-full font-mono" @blur="sectionModalAnchor = normalizeAnchorSlug(sectionModalAnchor)" />
+                            <p class="mt-1 text-xs text-zinc-500 dark:text-zinc-400">Opcional. Aceita letras, números e hífen. Exemplo no Header: /#introducao.</p>
+                        </div>
+                        <div>
                             <label class="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">Modo de capa dos módulos</label>
                             <div class="grid grid-cols-2 gap-3">
                                 <button
@@ -3291,6 +3327,11 @@ const inputClass = 'block w-full rounded-lg border border-zinc-300 bg-white px-3
                         <div>
                             <label class="mb-1 block text-sm font-medium text-zinc-700 dark:text-zinc-300">Título</label>
                             <input v-model="moduleModalTitle" type="text" :class="inputClass" placeholder="Título do módulo" class="w-full" />
+                        </div>
+                        <div>
+                            <label class="mb-1 block text-sm font-medium text-zinc-700 dark:text-zinc-300">Âncora do módulo</label>
+                            <input v-model="moduleModalAnchor" type="text" :class="inputClass" placeholder="modulo-1" class="w-full font-mono" @blur="moduleModalAnchor = normalizeAnchorSlug(moduleModalAnchor)" />
+                            <p class="mt-1 text-xs text-zinc-500 dark:text-zinc-400">Opcional. Se repetir uma âncora existente, o sistema cria uma variação segura.</p>
                         </div>
                         <!-- Cursos/Aulas: capa e mostrar título na capa -->
                         <template v-if="moduleModalSectionType === 'courses'">

--- a/resources/js/components/member-builder/MemberBuilderPreview.vue
+++ b/resources/js/components/member-builder/MemberBuilderPreview.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import { MessageSquare } from 'lucide-vue-next';
 import { getCommunityPageIconComponent } from '@/utils/communityPageIcons';
 
@@ -18,6 +18,8 @@ const props = defineProps({
     certificate_enabled: { type: Boolean, default: false },
     can_issue_certificate: { type: Boolean, default: false },
 });
+
+const previewScrollRef = ref(null);
 
 const theme = computed(() => props.config?.theme ?? {});
 const hero = computed(() => props.config?.hero ?? {});
@@ -58,6 +60,40 @@ const certOverlayOpacity = computed(() => {
     const raw = certificate.value.background_overlay_opacity ?? 50;
     return (raw <= 1 ? raw * 100 : raw) / 100;
 });
+
+function anchorFromLink(link) {
+    const raw = String(link || '').trim();
+    if (!raw) return '';
+    const hashIndex = raw.indexOf('#');
+    return hashIndex >= 0 ? raw.slice(hashIndex + 1).split(/[?&]/)[0] : '';
+}
+
+function previewItemHref(item) {
+    const link = String(item?.link || '/').trim() || '/';
+    return link.startsWith('#') ? `/${link}` : link;
+}
+
+function findPreviewAnchor(anchor) {
+    const root = previewScrollRef.value;
+    if (!root || !anchor) return null;
+    if (typeof CSS !== 'undefined' && CSS.escape) {
+        return root.querySelector(`#${CSS.escape(anchor)}`);
+    }
+    return root.querySelector(`[id="${anchor.replace(/"/g, '\\"')}"]`);
+}
+
+function handlePreviewMenuClick(event, item) {
+    const anchor = anchorFromLink(item?.link);
+    event.preventDefault();
+    if (!anchor) return;
+
+    const target = findPreviewAnchor(anchor);
+    const container = previewScrollRef.value;
+    if (!target || !container) return;
+
+    const top = target.getBoundingClientRect().top - container.getBoundingClientRect().top + container.scrollTop - 72;
+    container.scrollTo({ top: Math.max(0, top), behavior: 'smooth' });
+}
 </script>
 
 <template>
@@ -67,7 +103,7 @@ const certOverlayOpacity = computed(() => {
     >
         <!-- Área: estrutura idêntica à página real; scroll único (hero + conteúdo rolam juntos) -->
         <template v-if="mode === 'area'">
-            <div class="flex h-full min-h-[500px] w-full flex-col overflow-auto">
+            <div ref="previewScrollRef" class="flex h-full min-h-[500px] w-full flex-col overflow-auto scroll-smooth">
                 <!-- Hero + header em overlay -->
                 <div class="relative shrink-0">
                     <section
@@ -116,14 +152,16 @@ const certOverlayOpacity = computed(() => {
                                 {{ productName || 'Área de Membros' }}
                             </span>
                         </span>
-                        <nav class="flex items-center gap-1">
-                            <span
+                        <nav class="pointer-events-auto flex items-center gap-1">
+                            <a
                                 v-for="(item, i) in sidebarItems"
                                 :key="i"
+                                :href="previewItemHref(item)"
                                 class="rounded-lg px-3 py-2 text-sm font-medium text-white/90"
+                                @click="handlePreviewMenuClick($event, item)"
                             >
                                 {{ item.title }}
-                            </span>
+                            </a>
                             <span class="rounded-lg px-3 py-2 text-sm text-white/80">Sair</span>
                         </nav>
                     </header>
@@ -146,13 +184,14 @@ const certOverlayOpacity = computed(() => {
                             </section>
 
                             <!-- Módulos por seção — igual Show.vue, só aparece se houver sections -->
-                            <section v-for="section in sections" :key="section.id" class="space-y-4">
+                            <section v-for="section in sections" :id="section.anchor || null" :key="section.id" class="member-anchor-target space-y-4">
                                 <h2 class="text-xl font-semibold">{{ section.title }}</h2>
                                 <div class="flex gap-4 overflow-x-auto pb-2">
                                     <div
                                         v-for="mod in section.modules"
+                                        :id="mod.anchor || null"
                                         :key="mod.id"
-                                        class="flex w-64 shrink-0 flex-col rounded-xl overflow-hidden bg-zinc-800/50 transition hover:bg-zinc-800"
+                                        class="member-anchor-target flex w-64 shrink-0 flex-col rounded-xl overflow-hidden bg-zinc-800/50 transition hover:bg-zinc-800"
                                     >
                                         <div :class="[(section.cover_mode === 'horizontal' ? 'aspect-video' : 'aspect-[2/3]'), 'relative flex w-full items-center justify-center overflow-hidden bg-zinc-700']">
                                             <img v-if="mod.thumbnail" :src="mod.thumbnail" :alt="mod.title" class="absolute inset-0 h-full w-full object-cover" />

--- a/resources/js/lib/utils.js
+++ b/resources/js/lib/utils.js
@@ -5,6 +5,18 @@ export function cn(...inputs) {
     return twMerge(clsx(inputs));
 }
 
+export function normalizeAnchorSlug(value) {
+    if (value == null) return '';
+    return String(value)
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase()
+        .replace(/[^a-z0-9-]+/g, '-')
+        .replace(/-+/g, '-')
+        .replace(/^-|-$/g, '')
+        .slice(0, 120);
+}
+
 /**
  * Formata valor monetário em formato compacto (K = mil, M = milhão).
  * Ex: 1300 → 1.3K, 10000 → 10K, 1500000 → 1.5M


### PR DESCRIPTION
## Resumo

Implementei suporte a âncoras em seções e módulos da área de membros, permitindo que menus do Header levem o aluno diretamente para uma seção ou módulo específico da página.

## O que foi implementado

- Adicionado campo opcional **Âncora da seção** na criação e edição de seções.
- Adicionado campo opcional **Âncora do módulo** na criação e edição de módulos.
- Normalização automática das âncoras para slug seguro.
- Conversão de espaços, acentos e caracteres inválidos para formato limpo, como `modulo-1`.
- Prevenção de âncoras duplicadas dentro da mesma área, gerando variações seguras como `modulo-1-2`.
- Renderização automática do `id` correspondente nas seções e módulos da área do aluno.
- Suporte a links internos no Header usando formato como `/#introducao` ou `/#modulo-1`.
- Rolagem suave ao clicar em menus com âncoras.
- Ajuste para evitar que o conteúdo fique escondido atrás do header fixo.
- Funcionamento aplicado tanto na preview do builder quanto na área real do aluno.
- Preservado o comportamento existente de salvar, editar, excluir, visualizar e carregar seções, módulos e menus.

## Validação

- Build do frontend executado com sucesso.
- Sintaxe PHP validada nos arquivos alterados.
- Teste focado do Member Builder executado com sucesso.
- As alterações em `public/build` não foram incluídas no commit para manter o Pull Request limpo.
