### PR TITLE
fix: bloqueia acesso público a arquivos sensíveis e listagem de pastas

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -2,6 +2,11 @@
     RewriteEngine On
     RewriteBase /
 
+    # Segurança: Bloquear listagem e arquivos sensíveis
+    Options -Indexes
+    RewriteRule (^|/)\.(?!well-known) - [F]
+    RewriteRule ^(composer\.|package(-lock)?\.json|artisan|Dockerfile|docker-compose|phpunit\.xml|README\.md|CONTRIBUTING\.md|SECURITY\.md|VERSION) - [F]
+
     # Raiz (/) – redireciona diretamente para /login (evita 404)
     RewriteRule ^/?$ /login [R=302,L]
 


### PR DESCRIPTION
### 📝 Descrição
Implementação de regras de segurança no arquivo `.htaccess` para mitigar riscos de exposição de dados e informações do ambiente.

### 🛠️ Alterações realizadas
- Adicionadao `Options -Indexes` para impedir a listagem automática de arquivos em diretórios que não possuem um index.
- Bloqueio de acesso a arquivos ocultos (ex: `.env`, `.git`).
- Bloqueio de acesso a arquivos de configuração e sistema (ex: `composer.json`, `package.json`, `artisan`).

### 🛡️ Motivo (Segurança)
Identifiquei que arquivos críticos de configuração e o arquivo de ambiente (`.env`) estavam acessíveis diretamente via URL no navegador. Esta alteração corrige essa vulnerabilidade, impedindo que credenciais sensíveis e detalhes da infraestrutura sejam expostos publicamente.

### ✅ Validação
- Verificado que o acesso ao sistema (login) continua funcionando.
- Verificado que o instalador (`/install`) permanece operacional.
- Confirmado que o acesso direto ao `.env` agora retorna erro 403 Forbidden.