### PR TITLE
fix: permitir salvar R2 com taxas de moedas de alta precisão

### DIFF
--- a/resources/js/Pages/Settings/Index.vue
+++ b/resources/js/Pages/Settings/Index.vue
@@ -1223,7 +1223,7 @@ const selectClass =
                                                     v-if="getRateMode(index) === 'brl_to'"
                                                     v-model.number="curr.rate_to_brl"
                                                     type="number"
-                                                    step="0.0001"
+                                                    step="any"
                                                     min="0"
                                                     :class="inputClass"
                                                     :placeholder="curr.code === 'BRL' ? '1' : '0,18'"
@@ -1231,7 +1231,7 @@ const selectClass =
                                                 <input
                                                     v-else
                                                     type="number"
-                                                    step="0.01"
+                                                    step="any"
                                                     min="0"
                                                     :class="inputClass"
                                                     :placeholder="curr.code === 'BRL' ? '1' : '5,55'"

--- a/tests/Feature/StorageSettingsTest.php
+++ b/tests/Feature/StorageSettingsTest.php
@@ -9,6 +9,52 @@ use Tests\TestCase;
 
 class StorageSettingsTest extends TestCase
 {
+    public function test_r2_settings_can_be_saved_with_imported_currency_rate_precision(): void
+    {
+        $this->withoutMiddleware(EnsureInstalled::class);
+
+        $user = User::factory()->create([
+            'role' => User::ROLE_INFOPRODUTOR,
+            'tenant_id' => 1,
+        ]);
+
+        $this->actingAs($user)->put(route('settings.update'), [
+            'email_provider' => 'smtp',
+            'currencies' => [
+                [
+                    'code' => 'BRL',
+                    'symbol' => 'R$',
+                    'label' => 'Real brasileiro',
+                    'rate_to_brl' => 1,
+                ],
+                [
+                    'code' => 'AED',
+                    'symbol' => 'د.إ',
+                    'label' => 'Dirham dos Emirados Árabes Unidos',
+                    'rate_to_brl' => 0.720207,
+                ],
+            ],
+            'storage_provider' => 'r2',
+            'storage_s3_key' => 'r2-access-key',
+            'storage_s3_secret' => 'r2-secret-key',
+            'storage_s3_bucket' => 'r2-bucket',
+            'storage_s3_region' => 'auto',
+            'storage_s3_endpoint' => 'https://account.r2.cloudflarestorage.com',
+            'storage_s3_url' => 'https://files.example.com',
+        ])->assertRedirect()->assertSessionHasNoErrors();
+
+        $this->assertSame('r2', Setting::get('storage_provider', null, 1));
+        $this->assertSame('r2-access-key', Setting::get('storage_s3_key', null, 1));
+
+        $currencies = Setting::get('currencies', [], 1);
+        if (is_string($currencies)) {
+            $currencies = json_decode($currencies, true) ?: [];
+        }
+        $aed = collect($currencies)->firstWhere('code', 'AED');
+        $this->assertNotNull($aed);
+        $this->assertEqualsWithDelta(0.720207, (float) $aed['rate_to_brl'], 0.0000001);
+    }
+
     public function test_switching_to_local_preserves_saved_remote_storage_credentials(): void
     {
         $this->withoutMiddleware(EnsureInstalled::class);

--- a/tests/js/settingsCurrencyRatePrecision.test.mjs
+++ b/tests/js/settingsCurrencyRatePrecision.test.mjs
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const settingsPage = readFileSync(
+    new URL('../../resources/js/Pages/Settings/Index.vue', import.meta.url),
+    'utf8',
+);
+
+test('currency rate inputs accept imported rates with arbitrary decimal precision', () => {
+    const rateInputStart = settingsPage.indexOf('v-model.number="curr.rate_to_brl"');
+    assert.notEqual(rateInputStart, -1);
+
+    const rateInput = settingsPage.slice(rateInputStart, rateInputStart + 220);
+    assert.match(rateInput, /step="any"/);
+    assert.doesNotMatch(rateInput, /step="0\.0001"/);
+});
+
+test('inverse currency rate input does not block form submission due to step mismatch', () => {
+    const inverseInputStart = settingsPage.indexOf('v-else\n                                                    type="number"');
+    assert.notEqual(inverseInputStart, -1);
+
+    const inverseInput = settingsPage.slice(inverseInputStart, inverseInputStart + 180);
+    assert.match(inverseInput, /step="any"/);
+    assert.doesNotMatch(inverseInput, /step="0\.01"/);
+});


### PR DESCRIPTION
## Contexto

Ao salvar as configurações de Storage R2, o teste de conexão concluía com sucesso, mas o botão **Salvar alterações** aparentava não executar nenhuma ação.

A tela de configurações envia também a lista de moedas. Algumas taxas importadas possuem mais de quatro casas decimais, por exemplo `0.720207`, enquanto o campo `rate_to_brl` usava `step="0.0001"` e o campo de taxa inversa usava `step="0.01"`.

Nessa situação, a validação nativa do navegador marcava o input com `stepMismatch` e interrompia o submit antes de ele chegar ao Inertia/Laravel. Como o campo podia estar em uma aba não visível, o navegador também emitia `An invalid form control ... is not focusable`, deixando a impressão de que o botão não tinha ação.

## Correção

- Altera os dois inputs de taxa para `step="any"`.
- Mantém `type="number"`, portanto letras continuam inválidas.
- Mantém `min="0"`, impedindo taxas negativas.
- Preserva toda a precisão recebida das APIs de moedas, sem arredondar taxas como `0.720207`.

## Testes

- Teste JavaScript verifica que ambos os campos aceitam precisão decimal arbitrária e não reintroduzem os steps restritivos.
- Teste de integração salva uma configuração R2 junto com uma moeda AED de taxa `0.720207` e confirma a persistência das credenciais e da precisão completa.

Closes #83