### PR TITLE
feat: permitir reenvio manual de webhooks

### DIFF
--- a/app/Http/Controllers/WebhookController.php
+++ b/app/Http/Controllers/WebhookController.php
@@ -319,6 +319,78 @@ class WebhookController extends Controller
         ]);
     }
 
+    public function resendLog(Webhook $webhook, int $log): JsonResponse
+    {
+        $this->authorizeWebhook($webhook);
+
+        $originalLog = $webhook->logs()->findOrFail($log);
+        $body = $originalLog->request_payload;
+
+        if (! is_array($body) || $body === []) {
+            return response()->json([
+                'success' => false,
+                'message' => 'O payload original deste envio não está disponível.',
+            ], 422);
+        }
+
+        try {
+            $request = Http::timeout(15)
+                ->withHeaders(['Content-Type' => 'application/json'])
+                ->withBody(json_encode($body, JSON_THROW_ON_ERROR), 'application/json');
+
+            $token = $webhook->bearer_token;
+            if (is_string($token) && $token !== '') {
+                $request = $request->withToken($token);
+            }
+
+            $response = $request->post($webhook->url);
+            $responseStatus = $response->status();
+            $responseBody = $response->body();
+            $success = $response->successful();
+
+            WebhookLog::create([
+                'webhook_id' => $webhook->id,
+                'event' => $originalLog->event,
+                'event_label' => $originalLog->event_label,
+                'request_payload' => $body,
+                'response_status' => $responseStatus,
+                'response_body' => strlen($responseBody) > 2000 ? substr($responseBody, 0, 2000).'…' : $responseBody,
+                'success' => $success,
+                'error_message' => $success ? null : 'HTTP '.$responseStatus,
+                'source' => 'resend',
+            ]);
+
+            if (! $success) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Webhook reenviado, mas o destino retornou HTTP '.$responseStatus.'.',
+                ], 422);
+            }
+
+            return response()->json([
+                'success' => true,
+                'message' => 'Webhook reenviado com sucesso.',
+            ]);
+        } catch (\Throwable $e) {
+            WebhookLog::create([
+                'webhook_id' => $webhook->id,
+                'event' => $originalLog->event,
+                'event_label' => $originalLog->event_label,
+                'request_payload' => $body,
+                'response_status' => null,
+                'response_body' => null,
+                'success' => false,
+                'error_message' => $e->getMessage(),
+                'source' => 'resend',
+            ]);
+
+            return response()->json([
+                'success' => false,
+                'message' => 'Não foi possível reenviar o webhook.',
+            ], 500);
+        }
+    }
+
     private function authorizeWebhook(Webhook $webhook): void
     {
         $tenantId = auth()->user()->tenant_id;

--- a/resources/js/components/integrations/WebhookSidebar.vue
+++ b/resources/js/components/integrations/WebhookSidebar.vue
@@ -125,6 +125,9 @@ const loadingLogDetail = ref(false);
 const logCopyFeedback = ref('');
 const logRequestPreRef = ref(null);
 const logResponsePreRef = ref(null);
+const resendingLog = ref(false);
+const resendMessage = ref('');
+const resendSuccess = ref(null);
 
 const eventEntries = ref([]);
 
@@ -412,6 +415,8 @@ function formatLogDate(iso) {
 async function openLogDetail(webhookId, logId) {
     loadingLogDetail.value = true;
     selectedLogDetail.value = null;
+    resendMessage.value = '';
+    resendSuccess.value = null;
     logDetailModal.value = true;
     try {
         const { data } = await axios.get(
@@ -429,6 +434,39 @@ function closeLogDetail() {
     logDetailModal.value = false;
     selectedLogDetail.value = null;
     logCopyFeedback.value = '';
+    resendMessage.value = '';
+    resendSuccess.value = null;
+}
+
+function formatLogSource(source) {
+    if (source === 'test') return 'Teste manual';
+    if (source === 'resend') return 'Reenvio manual';
+    return 'Automático';
+}
+
+async function resendSelectedLog() {
+    const webhookId = logsWebhook.value?.id;
+    const logId = selectedLogDetail.value?.id;
+    if (!webhookId || !logId || resendingLog.value) return;
+
+    resendingLog.value = true;
+    resendMessage.value = '';
+    resendSuccess.value = null;
+
+    try {
+        const { data } = await axios.post(
+            `/integracoes/webhooks/${webhookId}/logs/${logId}/resend`,
+        );
+        resendSuccess.value = true;
+        resendMessage.value = data.message || 'Webhook reenviado com sucesso.';
+    } catch (err) {
+        resendSuccess.value = false;
+        resendMessage.value =
+            err.response?.data?.message || 'Não foi possível reenviar o webhook.';
+    } finally {
+        await Promise.all([fetchLogs(webhookId), fetchDashboard()]);
+        resendingLog.value = false;
+    }
 }
 
 function formatPayload(obj) {
@@ -917,7 +955,7 @@ function truncateUrl(url, max = 40) {
                                                 </span>
                                             </td>
                                             <td class="px-3 py-2.5 text-zinc-500">
-                                                {{ log.source === 'test' ? 'Teste' : 'Automático' }}
+                                                {{ formatLogSource(log.source) }}
                                             </td>
                                         </tr>
                                     </tbody>
@@ -1161,8 +1199,8 @@ function truncateUrl(url, max = 40) {
                                             (HTTP {{ selectedLogDetail.response_status }})
                                         </span>
                                     </span>
-                                    <span v-if="selectedLogDetail.source === 'test'" class="rounded bg-zinc-200 px-2 py-0.5 text-xs dark:bg-zinc-600">
-                                        Teste manual
+                                    <span class="rounded bg-zinc-200 px-2 py-0.5 text-xs dark:bg-zinc-600">
+                                        {{ formatLogSource(selectedLogDetail.source) }}
                                     </span>
                                     <span class="text-xs text-zinc-500 dark:text-zinc-400">
                                         {{ formatLogDate(selectedLogDetail.created_at) }}
@@ -1173,6 +1211,17 @@ function truncateUrl(url, max = 40) {
                                     class="mb-4 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-300"
                                 >
                                     {{ selectedLogDetail.error_message }}
+                                </p>
+                                <p
+                                    v-if="resendMessage"
+                                    class="mb-4 rounded-lg px-3 py-2 text-sm"
+                                    :class="
+                                        resendSuccess
+                                            ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-300'
+                                            : 'bg-red-50 text-red-700 dark:bg-red-900/20 dark:text-red-300'
+                                    "
+                                >
+                                    {{ resendMessage }}
                                 </p>
                                 <div class="space-y-4">
                                     <div>
@@ -1227,9 +1276,14 @@ function truncateUrl(url, max = 40) {
                                 </div>
                             </template>
                         </div>
-                        <div class="bg-zinc-50/80 px-5 py-3 dark:bg-zinc-800/80">
-                            <Button variant="outline" size="sm" class="w-full sm:w-auto" @click="closeLogDetail">
+                        <div class="flex flex-col-reverse gap-2 bg-zinc-50/80 px-5 py-3 sm:flex-row sm:justify-end dark:bg-zinc-800/80">
+                            <Button variant="outline" size="sm" class="w-full sm:w-auto" :disabled="resendingLog" @click="closeLogDetail">
                                 Fechar
+                            </Button>
+                            <Button size="sm" class="w-full sm:w-auto" :disabled="resendingLog || !selectedLogDetail" @click="resendSelectedLog">
+                                <Loader2 v-if="resendingLog" class="mr-2 h-4 w-4 animate-spin" />
+                                <Send v-else class="mr-2 h-4 w-4" />
+                                {{ resendingLog ? 'Reenviando…' : 'Reenviar webhook' }}
                             </Button>
                         </div>
                     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -646,6 +646,9 @@ Route::middleware(['auth', 'admin.tenant', 'role:admin|infoprodutor|team', 'audi
         Route::delete('/integracoes/webhooks/{webhook}', [\App\Http\Controllers\WebhookController::class, 'destroy'])->name('integrations.webhooks.destroy');
         Route::post('/integracoes/webhooks/{webhook}/test', [\App\Http\Controllers\WebhookController::class, 'test'])->name('integrations.webhooks.test');
         Route::get('/integracoes/webhooks/{webhook}/logs', [\App\Http\Controllers\WebhookController::class, 'logs'])->name('integrations.webhooks.logs');
+        Route::post('/integracoes/webhooks/{webhook}/logs/{log}/resend', [\App\Http\Controllers\WebhookController::class, 'resendLog'])
+            ->middleware('throttle:10,1')
+            ->name('integrations.webhooks.logs.resend');
         Route::get('/integracoes/webhooks/{webhook}/logs/{log}', [\App\Http\Controllers\WebhookController::class, 'showLog'])->name('integrations.webhooks.logs.show');
 
         Route::get('/integracoes/pixel-x', [\App\Http\Controllers\PixelXIntegrationController::class, 'index'])->name('integrations.pixel-x.index');

--- a/tests/Feature/WebhookResendTest.php
+++ b/tests/Feature/WebhookResendTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Events\OrderCompleted;
+use App\Http\Middleware\EnsureInstalled;
+use App\Models\User;
+use App\Models\Webhook;
+use App\Models\WebhookLog;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class WebhookResendTest extends TestCase
+{
+    public function test_owner_can_resend_a_logged_webhook_with_the_original_payload(): void
+    {
+        $this->withoutMiddleware(EnsureInstalled::class);
+        config(['app.key' => 'base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=']);
+        Http::fake(['hooks.example.com/*' => Http::response('received', 200)]);
+
+        $user = User::factory()->create([
+            'tenant_id' => 1,
+            'role' => User::ROLE_INFOPRODUTOR,
+        ]);
+        $webhook = Webhook::create([
+            'tenant_id' => 1,
+            'name' => 'CRM',
+            'url' => 'https://hooks.example.com/orders',
+            'bearer_token' => 'secret-token',
+            'events' => [OrderCompleted::class],
+            'is_active' => true,
+        ]);
+        $payload = [
+            'event' => 'pedido_pago',
+            'event_label' => 'Pedido pago',
+            'payload' => ['order' => ['id' => 123]],
+            'timestamp' => '2026-04-22T01:00:00-03:00',
+        ];
+        $originalLog = WebhookLog::create([
+            'webhook_id' => $webhook->id,
+            'event' => 'pedido_pago',
+            'event_label' => 'Pedido pago',
+            'request_payload' => $payload,
+            'response_status' => 500,
+            'response_body' => 'error',
+            'success' => false,
+            'error_message' => 'HTTP 500',
+            'source' => 'job',
+        ]);
+
+        $this->actingAs($user)
+            ->postJson(route('integrations.webhooks.logs.resend', [$webhook, $originalLog]))
+            ->assertOk()
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('message', 'Webhook reenviado com sucesso.');
+
+        Http::assertSent(fn ($request) =>
+            $request->url() === 'https://hooks.example.com/orders'
+            && $request->hasHeader('Authorization', 'Bearer secret-token')
+            && $request->data() === $payload
+        );
+
+        $resendLog = WebhookLog::query()
+            ->where('webhook_id', $webhook->id)
+            ->where('source', 'resend')
+            ->first();
+
+        $this->assertNotNull($resendLog);
+        $this->assertTrue($resendLog->success);
+        $this->assertSame(200, $resendLog->response_status);
+        $this->assertSame($payload, $resendLog->request_payload);
+    }
+
+    public function test_user_cannot_resend_another_tenants_webhook_log(): void
+    {
+        $this->withoutMiddleware(EnsureInstalled::class);
+        Http::fake();
+
+        $owner = User::factory()->create([
+            'tenant_id' => 1,
+            'role' => User::ROLE_INFOPRODUTOR,
+        ]);
+        $otherUser = User::factory()->create([
+            'tenant_id' => 2,
+            'role' => User::ROLE_INFOPRODUTOR,
+        ]);
+        $webhook = Webhook::create([
+            'tenant_id' => $owner->tenant_id,
+            'name' => 'CRM',
+            'url' => 'https://hooks.example.com/orders',
+            'events' => [OrderCompleted::class],
+            'is_active' => true,
+        ]);
+        $log = WebhookLog::create([
+            'webhook_id' => $webhook->id,
+            'event' => 'pedido_pago',
+            'event_label' => 'Pedido pago',
+            'request_payload' => ['event' => 'pedido_pago'],
+            'success' => false,
+            'source' => 'job',
+        ]);
+
+        $this->actingAs($otherUser)
+            ->postJson(route('integrations.webhooks.logs.resend', [$webhook, $log]))
+            ->assertNotFound();
+
+        Http::assertNothingSent();
+        $this->assertSame(1, WebhookLog::query()->count());
+    }
+}


### PR DESCRIPTION
## Contexto

A issue solicita uma forma de reenviar um webhook diretamente pelo card **Detalhe do envio**, facilitando testes e recuperações manuais.

## Implementação

- Adiciona o botão **Reenviar webhook** no rodapé do detalhe do log.
- Reenvia exatamente o envelope armazenado em `request_payload`.
- Usa a URL e o Bearer Token atuais do webhook.
- Registra cada tentativa como um novo log com origem `resend`.
- Exibe feedback de carregamento, sucesso ou erro sem fechar o modal.
- Identifica as entradas reenviadas como **Reenvio manual** na listagem e no detalhe.
- Atualiza logs e indicadores após a tentativa.

<img width="718" height="626" alt="image" src="https://github.com/user-attachments/assets/fb8b3b58-49d9-484f-ad59-9ec904d7626c" />
.
<img width="689" height="32" alt="image" src="https://github.com/user-attachments/assets/918c317a-bfe9-49fc-8593-3d2a5822d4d8" />



## Segurança e controle

- Valida que webhook e log pertencem ao tenant autenticado.
- Retorna 404 para tentativas entre tenants.
- Limita o endpoint a 10 reenvios por minuto.
- Registra também respostas HTTP não bem-sucedidas e exceções.

## Testes

- Confirma o reenvio do payload original com Bearer Token.
- Confirma a criação de um novo log de reenvio.
- Confirma o isolamento entre tenants.
- 2 testes aprovados, com 11 asserções.
- Componente Vue compilado com sucesso.

Closes #52