### PR TITLE
feat: adiciona relatório de desempenho de Order Bumps

### DIFF
--- a/app/Http/Controllers/CheckoutController.php
+++ b/app/Http/Controllers/CheckoutController.php
@@ -904,6 +904,7 @@ class CheckoutController extends Controller
                     'product_id' => $bump->target_product_id,
                     'product_offer_id' => $bump->target_product_offer_id,
                     'subscription_plan_id' => $bump->target_subscription_plan_id,
+                    'product_order_bump_id' => $bump->id,
                     'amount' => $bump->getEffectiveAmountBrl(),
                     'position' => $pos++,
                 ]);
@@ -2191,6 +2192,7 @@ class CheckoutController extends Controller
                     'product_id' => $bump->target_product_id,
                     'product_offer_id' => $bump->target_product_offer_id,
                     'subscription_plan_id' => $bump->target_subscription_plan_id,
+                    'product_order_bump_id' => $bump->id,
                     'amount' => CheckoutCustomPriceByCurrency::bumpBrlToChargeCurrency(
                         $bump->getEffectiveAmountBrl(),
                         $chargeCurrency,
@@ -2373,6 +2375,7 @@ class CheckoutController extends Controller
                 'product_id' => $bump->target_product_id,
                 'product_offer_id' => $bump->target_product_offer_id,
                 'subscription_plan_id' => $bump->target_subscription_plan_id,
+                'product_order_bump_id' => $bump->id,
                 'amount' => $bump->getEffectiveAmountBrl(),
                 'position' => $pos++,
             ]);

--- a/app/Http/Controllers/RelatoriosController.php
+++ b/app/Http/Controllers/RelatoriosController.php
@@ -7,6 +7,7 @@ use App\Models\Order;
 use App\Models\Product;
 use App\Models\User;
 use App\Services\MetaCustomAudienceCsvService;
+use App\Services\OrderBumpReportService;
 use App\Support\ReportingPeriod;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
@@ -15,10 +16,11 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class RelatoriosController extends Controller
 {
-    private const PERIODS = ['hoje', 'ontem', '7dias', 'mes', 'ano', 'total'];
+    private const PERIODS = ['hoje', 'ontem', '7dias', 'mes', 'ano', 'total', 'personalizado'];
 
     public function __construct(
-        private MetaCustomAudienceCsvService $metaCustomAudienceCsv
+        private MetaCustomAudienceCsvService $metaCustomAudienceCsv,
+        private OrderBumpReportService $orderBumpReport,
     ) {}
 
     public function index(Request $request): Response
@@ -28,8 +30,22 @@ class RelatoriosController extends Controller
             $period = 'hoje';
         }
 
+        $dateFrom = null;
+        $dateTo = null;
+        if ($period === 'personalizado') {
+            $dateFrom = (string) $request->query('date_from', ReportingPeriod::now()->startOfMonth()->toDateString());
+            $dateTo = (string) $request->query('date_to', ReportingPeriod::now()->toDateString());
+            $request->merge(['date_from' => $dateFrom, 'date_to' => $dateTo]);
+            $request->validate([
+                'date_from' => ['required', 'date_format:Y-m-d'],
+                'date_to' => ['required', 'date_format:Y-m-d', 'after_or_equal:date_from'],
+            ]);
+            [$start, $end] = ReportingPeriod::boundsForVendas('custom', $dateFrom, $dateTo);
+        } else {
+            [$start, $end] = ReportingPeriod::boundsForDashboard($period);
+        }
+
         $tenantId = auth()->user()->tenant_id;
-        [$start, $end] = ReportingPeriod::boundsForDashboard($period);
 
         $ordersQuery = Order::forTenant($tenantId);
         ReportingPeriod::applyCreatedAtBounds($ordersQuery, $start, $end);
@@ -136,8 +152,18 @@ class RelatoriosController extends Controller
             ->values()
             ->all();
 
+        $orderBumpReport = $this->orderBumpReport->build(
+            $tenantId,
+            $request->query('order_bump_product_id'),
+            $start,
+            $end,
+        );
+
         return Inertia::render('Relatorios/Index', [
             'period' => $period,
+            'date_from' => $dateFrom,
+            'date_to' => $dateTo,
+            'order_bump_report' => $orderBumpReport,
             'meta_export_products' => $this->metaCustomAudienceCsv->productsForExportDropdown($request->user()),
             'receita_total' => round($receitaTotal, 2),
             'quantidade_vendas' => $quantidadeVendas,

--- a/app/Models/OrderItem.php
+++ b/app/Models/OrderItem.php
@@ -12,6 +12,7 @@ class OrderItem extends Model
         'product_id',
         'product_offer_id',
         'subscription_plan_id',
+        'product_order_bump_id',
         'amount',
         'position',
     ];
@@ -41,5 +42,10 @@ class OrderItem extends Model
     public function subscriptionPlan(): BelongsTo
     {
         return $this->belongsTo(SubscriptionPlan::class);
+    }
+
+    public function productOrderBump(): BelongsTo
+    {
+        return $this->belongsTo(ProductOrderBump::class);
     }
 }

--- a/app/Services/OrderBumpReportService.php
+++ b/app/Services/OrderBumpReportService.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\OrderItem;
+use App\Models\Product;
+use App\Models\ProductOrderBump;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+
+class OrderBumpReportService
+{
+    /**
+     * @return array{products: list<array{id: string, name: string}>, selected_product_id: ?string, eligible_orders: int, accepted_items: int, bumps: list<array{id: int, title: string, target_name: string, sales_count: int, acceptance_rate: float}>}
+     */
+    public function build(?int $tenantId, ?string $requestedProductId, ?Carbon $start, ?Carbon $end): array
+    {
+        $productsQuery = Product::forTenant($tenantId)
+            ->whereHas('orderBumps')
+            ->orderBy('name');
+
+        $products = $productsQuery->get(['id', 'name']);
+        $selected = $requestedProductId
+            ? $products->firstWhere('id', $requestedProductId)
+            : $products->first();
+
+        if (! $selected) {
+            return [
+                'products' => $this->productOptions($products),
+                'selected_product_id' => null,
+                'eligible_orders' => 0,
+                'accepted_items' => 0,
+                'bumps' => [],
+            ];
+        }
+
+        $bumps = ProductOrderBump::query()
+            ->where('product_id', $selected->id)
+            ->with('targetProduct:id,name')
+            ->orderBy('position')
+            ->orderBy('id')
+            ->get();
+
+        $eligibleOrders = \App\Models\Order::forTenant($tenantId)
+            ->where('product_id', $selected->id)
+            ->where('status', 'completed');
+        $this->applyOrderBounds($eligibleOrders, $start, $end);
+        $eligibleOrdersCount = $eligibleOrders->count();
+
+        $signatureCounts = $bumps->countBy(fn (ProductOrderBump $bump) => $this->signature($bump));
+        $rows = $bumps->map(function (ProductOrderBump $bump) use ($tenantId, $selected, $start, $end, $eligibleOrdersCount, $signatureCounts) {
+            $directCount = $this->itemsQuery($tenantId, (string) $selected->id, $start, $end)
+                ->where('order_items.product_order_bump_id', $bump->id)
+                ->count();
+
+            $legacyCount = 0;
+            if (($signatureCounts[$this->signature($bump)] ?? 0) === 1) {
+                $legacy = $this->itemsQuery($tenantId, (string) $selected->id, $start, $end)
+                    ->whereNull('order_items.product_order_bump_id')
+                    ->where('order_items.position', '>', 0)
+                    ->where('order_items.product_id', $bump->target_product_id);
+
+                $this->whereNullableId($legacy, 'order_items.product_offer_id', $bump->target_product_offer_id);
+                $this->whereNullableId($legacy, 'order_items.subscription_plan_id', $bump->target_subscription_plan_id);
+                $legacyCount = $legacy->count();
+            }
+
+            $salesCount = $directCount + $legacyCount;
+
+            return [
+                'id' => (int) $bump->id,
+                'title' => (string) $bump->title,
+                'target_name' => (string) ($bump->targetProduct?->name ?? 'Produto removido'),
+                'sales_count' => $salesCount,
+                'acceptance_rate' => $eligibleOrdersCount > 0
+                    ? round($salesCount / $eligibleOrdersCount * 100, 1)
+                    : 0.0,
+            ];
+        })->values();
+
+        return [
+            'products' => $this->productOptions($products),
+            'selected_product_id' => (string) $selected->id,
+            'eligible_orders' => $eligibleOrdersCount,
+            'accepted_items' => (int) $rows->sum('sales_count'),
+            'bumps' => $rows->all(),
+        ];
+    }
+
+    private function itemsQuery(?int $tenantId, string $productId, ?Carbon $start, ?Carbon $end): Builder
+    {
+        $query = OrderItem::query()
+            ->join('orders', 'orders.id', '=', 'order_items.order_id')
+            ->where('orders.product_id', $productId)
+            ->where('orders.status', 'completed')
+            ->when($tenantId === null, fn ($q) => $q->whereNull('orders.tenant_id'), fn ($q) => $q->where('orders.tenant_id', $tenantId));
+
+        $this->applyOrderBounds($query, $start, $end);
+
+        return $query;
+    }
+
+    private function applyOrderBounds(Builder $query, ?Carbon $start, ?Carbon $end): void
+    {
+        if ($start && $end) {
+            $query->whereBetween('orders.created_at', [$start, $end]);
+        } elseif ($start) {
+            $query->where('orders.created_at', '>=', $start);
+        } elseif ($end) {
+            $query->where('orders.created_at', '<=', $end);
+        }
+    }
+
+    private function whereNullableId(Builder $query, string $column, mixed $value): void
+    {
+        $value === null ? $query->whereNull($column) : $query->where($column, $value);
+    }
+
+    private function signature(ProductOrderBump $bump): string
+    {
+        return implode(':', [
+            $bump->target_product_id,
+            $bump->target_product_offer_id ?? 'null',
+            $bump->target_subscription_plan_id ?? 'null',
+        ]);
+    }
+
+    /** @return list<array{id: string, name: string}> */
+    private function productOptions(Collection $products): array
+    {
+        return $products->map(fn (Product $product) => [
+            'id' => (string) $product->id,
+            'name' => (string) $product->name,
+        ])->values()->all();
+    }
+}

--- a/database/migrations/2026_07_15_000001_add_product_order_bump_id_to_order_items_table.php
+++ b/database/migrations/2026_07_15_000001_add_product_order_bump_id_to_order_items_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('order_items', function (Blueprint $table) {
+            $table->foreignId('product_order_bump_id')
+                ->nullable()
+                ->after('subscription_plan_id')
+                ->constrained('product_order_bumps')
+                ->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('order_items', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('product_order_bump_id');
+        });
+    }
+};

--- a/resources/js/Pages/Relatorios/Index.vue
+++ b/resources/js/Pages/Relatorios/Index.vue
@@ -15,6 +15,7 @@ import {
     EyeOff,
     XCircle,
     Download,
+    BarChart3,
 } from 'lucide-vue-next';
 
 defineOptions({ layout: LayoutInfoprodutor });
@@ -28,6 +29,8 @@ onMounted(() => {
 
 const props = defineProps({
     period: { type: String, default: 'hoje' },
+    date_from: { type: String, default: '' },
+    date_to: { type: String, default: '' },
     receita_total: { type: Number, default: 0 },
     quantidade_vendas: { type: Number, default: 0 },
     ticket_medio: { type: Number, default: 0 },
@@ -44,6 +47,10 @@ const props = defineProps({
     reembolsos_count: { type: Number, default: 0 },
     reembolsos_total: { type: Number, default: 0 },
     meta_export_products: { type: Array, default: () => [] },
+    order_bump_report: {
+        type: Object,
+        default: () => ({ products: [], selected_product_id: null, eligible_orders: 0, accepted_items: 0, bumps: [] }),
+    },
 });
 
 const META_HEADER =
@@ -53,6 +60,9 @@ const showModalCompradores = ref(false);
 const showModalAbandonos = ref(false);
 const productCompradores = ref('');
 const productAbandonos = ref('');
+const customDateFrom = ref(props.date_from || new Date().toISOString().slice(0, 10));
+const customDateTo = ref(props.date_to || new Date().toISOString().slice(0, 10));
+const orderBumpProductId = ref(props.order_bump_report.selected_product_id || '');
 
 function openModalCompradores() {
     productCompradores.value = props.meta_export_products[0]?.id ?? '';
@@ -81,10 +91,34 @@ const periodOptions = [
     { value: 'mes', label: 'Mês' },
     { value: 'ano', label: 'Ano' },
     { value: 'total', label: 'Total' },
+    { value: 'personalizado', label: 'Personalizado' },
 ];
 
 function setPeriod(value) {
-    router.get('/relatorios', { period: value }, { preserveState: false });
+    const params = { period: value };
+    if (orderBumpProductId.value) params.order_bump_product_id = orderBumpProductId.value;
+    if (value === 'personalizado') {
+        params.date_from = customDateFrom.value;
+        params.date_to = customDateTo.value;
+    }
+    router.get('/relatorios', params, { preserveState: false });
+}
+
+function applyCustomPeriod() {
+    if (!customDateFrom.value || !customDateTo.value) return;
+    setPeriod('personalizado');
+}
+
+function setOrderBumpProduct() {
+    const params = {
+        period: props.period,
+        order_bump_product_id: orderBumpProductId.value,
+    };
+    if (props.period === 'personalizado') {
+        params.date_from = customDateFrom.value;
+        params.date_to = customDateTo.value;
+    }
+    router.get('/relatorios', params, { preserveState: false });
 }
 
 function formatBRL(value) {
@@ -219,6 +253,39 @@ const chartOptionsFormas = computed(() => ({
                 </button>
             </div>
         </div>
+
+        <form
+            v-if="period === 'personalizado'"
+            class="flex flex-wrap items-end gap-3 rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-800/60"
+            @submit.prevent="applyCustomPeriod"
+        >
+            <label class="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                Data inicial
+                <input
+                    v-model="customDateFrom"
+                    type="date"
+                    required
+                    :max="customDateTo || undefined"
+                    class="mt-1 block rounded-lg border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-900 dark:text-white"
+                />
+            </label>
+            <label class="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                Data final
+                <input
+                    v-model="customDateTo"
+                    type="date"
+                    required
+                    :min="customDateFrom || undefined"
+                    class="mt-1 block rounded-lg border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-900 dark:text-white"
+                />
+            </label>
+            <button
+                type="submit"
+                class="rounded-lg bg-[var(--color-primary)] px-4 py-2 text-sm font-medium text-white"
+            >
+                Aplicar período
+            </button>
+        </form>
 
         <p
             v-if="!meta_export_products.length"
@@ -413,6 +480,81 @@ const chartOptionsFormas = computed(() => ({
                 </div>
             </div>
         </div>
+
+        <section class="panel-card-md">
+            <div class="flex flex-wrap items-start justify-between gap-4">
+                <div>
+                    <h2 class="flex items-center gap-2 text-base font-semibold text-zinc-900 dark:text-white">
+                        <BarChart3 class="h-5 w-5 text-zinc-500" />
+                        Desempenho dos Order Bumps
+                    </h2>
+                    <p class="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+                        Vendas concluídas no período selecionado, incluindo ofertas sem nenhuma aceitação.
+                    </p>
+                </div>
+                <label v-if="order_bump_report.products.length" class="min-w-64 text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                    Produto principal
+                    <select
+                        v-model="orderBumpProductId"
+                        class="mt-1 block w-full rounded-lg border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-900 dark:text-white"
+                        @change="setOrderBumpProduct"
+                    >
+                        <option v-for="product in order_bump_report.products" :key="product.id" :value="product.id">
+                            {{ product.name }}
+                        </option>
+                    </select>
+                </label>
+            </div>
+
+            <div v-if="order_bump_report.products.length" class="mt-5 grid gap-3 sm:grid-cols-2">
+                <div class="rounded-xl bg-zinc-50 p-4 dark:bg-zinc-800">
+                    <p class="text-xs font-medium uppercase tracking-wide text-zinc-500">Pedidos concluídos</p>
+                    <p class="mt-1 text-2xl font-bold text-zinc-900 dark:text-white">
+                        {{ displayNumber(order_bump_report.eligible_orders) }}
+                    </p>
+                </div>
+                <div class="rounded-xl bg-zinc-50 p-4 dark:bg-zinc-800">
+                    <p class="text-xs font-medium uppercase tracking-wide text-zinc-500">Order Bumps vendidos</p>
+                    <p class="mt-1 text-2xl font-bold text-zinc-900 dark:text-white">
+                        {{ displayNumber(order_bump_report.accepted_items) }}
+                    </p>
+                </div>
+            </div>
+
+            <div v-if="order_bump_report.products.length" class="mt-5 overflow-hidden rounded-lg border border-zinc-200 dark:border-zinc-700">
+                <table class="min-w-full divide-y divide-zinc-200 dark:divide-zinc-700">
+                    <thead class="bg-zinc-100/80 dark:bg-zinc-800/80">
+                        <tr>
+                            <th class="px-4 py-2 text-left text-xs font-medium uppercase text-zinc-500">Order Bump</th>
+                            <th class="px-4 py-2 text-left text-xs font-medium uppercase text-zinc-500">Produto ofertado</th>
+                            <th class="px-4 py-2 text-right text-xs font-medium uppercase text-zinc-500">Vendas</th>
+                            <th class="px-4 py-2 text-right text-xs font-medium uppercase text-zinc-500">Aceitação</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-zinc-200 dark:divide-zinc-700">
+                        <tr v-for="bump in order_bump_report.bumps" :key="bump.id" class="bg-white dark:bg-zinc-800/60">
+                            <td class="px-4 py-3 text-sm font-medium text-zinc-900 dark:text-white">{{ bump.title }}</td>
+                            <td class="px-4 py-3 text-sm text-zinc-600 dark:text-zinc-300">{{ bump.target_name }}</td>
+                            <td class="px-4 py-3 text-right text-sm font-semibold text-zinc-900 dark:text-white">
+                                {{ displayNumber(bump.sales_count) }}
+                            </td>
+                            <td class="px-4 py-3 text-right text-sm text-zinc-600 dark:text-zinc-300">
+                                {{ valuesVisible ? `${bump.acceptance_rate}%` : '—' }}
+                            </td>
+                        </tr>
+                        <tr v-if="!order_bump_report.bumps.length" class="bg-white dark:bg-zinc-800/60">
+                            <td colspan="4" class="px-4 py-8 text-center text-sm text-zinc-500">
+                                Este produto não possui Order Bumps configurados.
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+            <p v-else class="mt-5 rounded-lg border border-dashed border-zinc-300 px-4 py-8 text-center text-sm text-zinc-500 dark:border-zinc-700">
+                Nenhum produto possui Order Bumps configurados.
+            </p>
+        </section>
 
         <div class="grid gap-4 lg:grid-cols-3">
             <div class="panel-card-md lg:col-span-2">

--- a/tests/Feature/OrderBumpReportTest.php
+++ b/tests/Feature/OrderBumpReportTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Middleware\EnsureInstalled;
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\ProductOrderBump;
+use App\Models\User;
+use App\Services\OrderBumpReportService;
+use Inertia\Testing\AssertableInertia as Assert;
+use Tests\TestCase;
+
+class OrderBumpReportTest extends TestCase
+{
+    public function test_report_counts_direct_and_legacy_sales_and_keeps_zero_sales_bumps(): void
+    {
+        $main = $this->createTestProduct(['name' => 'Produto principal']);
+        $targetA = $this->createTestProduct(['name' => 'Bônus A']);
+        $targetB = $this->createTestProduct(['name' => 'Bônus B']);
+
+        $bumpA = ProductOrderBump::create([
+            'product_id' => $main->id,
+            'target_product_id' => $targetA->id,
+            'title' => 'Order Bump A',
+            'cta_title' => 'Adicionar A',
+            'position' => 0,
+        ]);
+        $bumpB = ProductOrderBump::create([
+            'product_id' => $main->id,
+            'target_product_id' => $targetB->id,
+            'title' => 'Order Bump B',
+            'cta_title' => 'Adicionar B',
+            'position' => 1,
+        ]);
+
+        $directOrder = $this->completedOrder($main->id, now()->subDay());
+        OrderItem::create([
+            'order_id' => $directOrder->id,
+            'product_id' => $targetA->id,
+            'product_order_bump_id' => $bumpA->id,
+            'amount' => 20,
+            'position' => 1,
+        ]);
+
+        $legacyOrder = $this->completedOrder($main->id, now()->subDays(2));
+        OrderItem::create([
+            'order_id' => $legacyOrder->id,
+            'product_id' => $targetA->id,
+            'amount' => 20,
+            'position' => 1,
+        ]);
+
+        $this->completedOrder($main->id, now()->subDays(3));
+        $outsidePeriod = $this->completedOrder($main->id, now()->subDays(40));
+        OrderItem::create([
+            'order_id' => $outsidePeriod->id,
+            'product_id' => $targetA->id,
+            'product_order_bump_id' => $bumpA->id,
+            'amount' => 20,
+            'position' => 1,
+        ]);
+
+        $report = app(OrderBumpReportService::class)->build(
+            1,
+            (string) $main->id,
+            now()->subDays(7)->startOfDay(),
+            now()->endOfDay(),
+        );
+
+        $this->assertSame(3, $report['eligible_orders']);
+        $this->assertSame(2, $report['accepted_items']);
+        $this->assertCount(2, $report['bumps']);
+        $this->assertSame(2, $report['bumps'][0]['sales_count']);
+        $this->assertSame(66.7, $report['bumps'][0]['acceptance_rate']);
+        $this->assertSame(0, $report['bumps'][1]['sales_count']);
+        $this->assertSame(0.0, $report['bumps'][1]['acceptance_rate']);
+        $this->assertSame('Bônus B', $report['bumps'][1]['target_name']);
+    }
+
+    public function test_report_does_not_mix_other_tenants(): void
+    {
+        $main = $this->createTestProduct(['tenant_id' => 1]);
+        $target = $this->createTestProduct(['tenant_id' => 1]);
+        $bump = ProductOrderBump::create([
+            'product_id' => $main->id,
+            'target_product_id' => $target->id,
+            'title' => 'Bump',
+            'cta_title' => 'Adicionar',
+        ]);
+
+        $foreignOrder = $this->completedOrder($main->id, now(), 2);
+        OrderItem::create([
+            'order_id' => $foreignOrder->id,
+            'product_id' => $target->id,
+            'product_order_bump_id' => $bump->id,
+            'amount' => 10,
+            'position' => 1,
+        ]);
+
+        $report = app(OrderBumpReportService::class)->build(1, (string) $main->id, null, null);
+
+        $this->assertSame(0, $report['eligible_orders']);
+        $this->assertSame(0, $report['bumps'][0]['sales_count']);
+    }
+
+    public function test_reports_page_exposes_order_bumps_for_custom_period(): void
+    {
+        $this->withoutMiddleware(EnsureInstalled::class);
+
+        $user = User::factory()->create([
+            'role' => User::ROLE_INFOPRODUTOR,
+            'tenant_id' => 1,
+        ]);
+        $main = $this->createTestProduct(['name' => 'Produto do relatório']);
+        $target = $this->createTestProduct(['name' => 'Oferta adicional']);
+        ProductOrderBump::create([
+            'product_id' => $main->id,
+            'target_product_id' => $target->id,
+            'title' => 'Bump do relatório',
+            'cta_title' => 'Adicionar',
+        ]);
+
+        $this->actingAs($user)
+            ->get('/relatorios?period=personalizado&date_from=2026-07-01&date_to=2026-07-31&order_bump_product_id='.$main->id)
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('Relatorios/Index')
+                ->where('period', 'personalizado')
+                ->where('date_from', '2026-07-01')
+                ->where('date_to', '2026-07-31')
+                ->where('order_bump_report.selected_product_id', (string) $main->id)
+                ->where('order_bump_report.bumps.0.title', 'Bump do relatório')
+                ->where('order_bump_report.bumps.0.sales_count', 0)
+            );
+    }
+
+    private function completedOrder(string $productId, \DateTimeInterface $createdAt, int $tenantId = 1): Order
+    {
+        $order = Order::create([
+            'tenant_id' => $tenantId,
+            'product_id' => $productId,
+            'status' => 'completed',
+            'amount' => 100,
+            'currency' => 'BRL',
+            'email' => uniqid('buyer-', true).'@example.com',
+            'gateway' => 'manual',
+        ]);
+
+        $order->forceFill([
+            'created_at' => $createdAt,
+            'updated_at' => $createdAt,
+        ])->save();
+
+        return $order->fresh();
+    }
+}


### PR DESCRIPTION
## O que foi alterado

- adiciona relatório consolidado de Order Bumps na página `/relatorios`;
- permite filtrar pelo produto principal e por períodos rápidos ou intervalo personalizado;
- exibe pedidos concluídos, quantidade vendida e taxa de aceitação de cada bump;
- mantém no relatório bumps com zero vendas;
- associa novas linhas de pedido à configuração de Order Bump que as originou;
- mantém compatibilidade com vendas antigas por meio da combinação produto/oferta/plano;
- isola os dados por tenant.

<img width="1043" height="333" alt="image" src="https://github.com/user-attachments/assets/6ec1fd0d-9080-4a10-8f2f-106f605b2a3d" />


## Motivação

Antes, era necessário abrir cada venda individualmente para identificar quais Order Bumps haviam sido aceitos. O relatório fornece uma visão consolidada para comparar o desempenho das ofertas e tomar decisões de otimização.

## Banco de dados

Adiciona a coluna nullable `product_order_bump_id` em `order_items`, com chave estrangeira e `nullOnDelete`.

## Validação

- 3 testes novos, 32 asserções;
- suíte focada de relatórios e períodos: 10 testes, 31 asserções;
- build de produção do Vite concluído com sucesso;
- teste manual local com dados distribuídos em 45 dias.

Fixes #78