### PR TITLE
feat: add visual email template editor

### DIFF
--- a/app/Http/Controllers/ProdutosController.php
+++ b/app/Http/Controllers/ProdutosController.php
@@ -410,6 +410,7 @@ class ProdutosController extends Controller
 
         return Inertia::render('Produtos/Edit', [
             'produto' => $produtoArray,
+            'default_cart_recovery_email' => Product::defaultCheckoutConfig()['cart_recovery_email'],
             'productTypes' => $productTypes,
             'billingTypes' => $billingTypes,
             'exchange_rates' => $this->legacyExchangeRatesMap($tenantCurrencies),

--- a/app/Jobs/SendCheckoutSessionRecoveryEmailJob.php
+++ b/app/Jobs/SendCheckoutSessionRecoveryEmailJob.php
@@ -84,11 +84,11 @@ class SendCheckoutSessionRecoveryEmailJob implements ShouldQueue
         ];
 
         $subject = str_replace(array_keys($replace), array_values($replace), $subjectTpl);
-        if (trim($bodyTextTpl) !== '') {
+        if (trim($bodyHtmlTpl) !== '') {
+            $body = str_replace(array_keys($replace), array_values($replace), $bodyHtmlTpl);
+        } else {
             $text = str_replace(array_keys($replace), array_values($replace), $bodyTextTpl);
             $body = $this->wrapTextInPrettyHtml($text, $checkoutUrl);
-        } else {
-            $body = str_replace(array_keys($replace), array_values($replace), $bodyHtmlTpl);
         }
 
         try {
@@ -144,4 +144,3 @@ class SendCheckoutSessionRecoveryEmailJob implements ShouldQueue
             . '</td></tr></table></td></tr></table>';
     }
 }
-

--- a/app/Jobs/SendPendingOrderRecoveryEmailJob.php
+++ b/app/Jobs/SendPendingOrderRecoveryEmailJob.php
@@ -90,11 +90,11 @@ class SendPendingOrderRecoveryEmailJob implements ShouldQueue
         ];
 
         $subject = str_replace(array_keys($replace), array_values($replace), $subjectTpl);
-        if (trim($bodyTextTpl) !== '') {
+        if (trim($bodyHtmlTpl) !== '') {
+            $body = str_replace(array_keys($replace), array_values($replace), $bodyHtmlTpl);
+        } else {
             $text = str_replace(array_keys($replace), array_values($replace), $bodyTextTpl);
             $body = $this->wrapTextInPrettyHtml($text, $checkoutUrl);
-        } else {
-            $body = str_replace(array_keys($replace), array_values($replace), $bodyHtmlTpl);
         }
 
         try {
@@ -156,4 +156,3 @@ class SendPendingOrderRecoveryEmailJob implements ShouldQueue
             . '</td></tr></table></td></tr></table>';
     }
 }
-

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -87,7 +87,7 @@ class Product extends Model
      */
     public static function defaultCheckoutConfig(): array
     {
-        return [
+        $config = [
             'summary' => [
                 'previous_price' => null,
                 'discount_text' => '',
@@ -299,6 +299,39 @@ class Product extends Model
                         'body_html' => '<table width=\"100%\" cellpadding=\"0\" cellspacing=\"0\" border=\"0\" style=\"max-width:600px;margin:0 auto;font-family:\'Segoe UI\',Tahoma,sans-serif;background:#f8fafc;padding:32px 24px;\"><tr><td style=\"background:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.08);\"><table width=\"100%\" cellpadding=\"0\" cellspacing=\"0\"><tr><td style=\"padding:28px 32px;\"><h1 style=\"margin:0 0 12px;font-size:20px;font-weight:700;color:#0f172a;\">Último lembrete</h1><p style=\"margin:0 0 16px;font-size:15px;line-height:1.6;color:#334155;\">Deixando aqui seu link para concluir a compra de <strong>{nome_produto}</strong> quando for melhor:</p><p style=\"margin:0 0 22px;text-align:center;\"><a href=\"{link_checkout}\" style=\"display:inline-block;padding:14px 28px;background:#0ea5e9;color:#ffffff;text-decoration:none;font-weight:700;font-size:15px;border-radius:10px;\">Concluir compra</a></p><p style=\"margin:0;font-size:13px;line-height:1.6;color:#64748b;\">Se você já concluiu, pode ignorar este e-mail.</p></td></tr></table></td></tr></table>',
                     ],
                 ],
+            ],
+        ];
+
+        foreach (static::defaultCartRecoveryEmailLayouts() as $stage => $layout) {
+            $config['cart_recovery_email']['stages'][$stage] = $layout;
+        }
+
+        return $config;
+    }
+
+    /**
+     * @return array<string, array{subject: string, body_text: string, body_html: string}>
+     */
+    private static function defaultCartRecoveryEmailLayouts(): array
+    {
+        $shellStart = '<table width="100%" cellpadding="0" cellspacing="0" border="0" style="max-width:600px;margin:0 auto;font-family:\'Segoe UI\',Tahoma,sans-serif;background:#f1f5f9;padding:36px 24px;"><tr><td style="background:#ffffff;border-radius:16px;overflow:hidden;box-shadow:0 8px 24px rgba(15,23,42,0.08);">';
+        $shellEnd = '</td></tr></table>';
+
+        return [
+            '10m' => [
+                'subject' => 'Você ainda quer garantir {nome_produto}?',
+                'body_text' => "Olá, {nome_cliente}!\n\nVocê estava a poucos passos de concluir sua compra de {nome_produto}. Deixamos tudo pronto para você continuar de onde parou.\n\nProduto: {nome_produto}\nValor: {valor}\n\nRetome sua compra com segurança:\n{link_checkout}\n\nSe tiver alguma dúvida, responda este e-mail. Estamos à disposição para ajudar.",
+                'body_html' => $shellStart.'<div style="height:6px;background:#0ea5e9;"></div><div style="padding:32px;"><p style="margin:0 0 10px;font-size:12px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:#0284c7;">Sua compra está esperando por você</p><h1 style="margin:0 0 14px;font-size:24px;line-height:1.3;color:#0f172a;">Olá, {nome_cliente}!</h1><p style="margin:0 0 22px;font-size:15px;line-height:1.7;color:#475569;">Você estava a poucos passos de concluir sua compra. Deixamos tudo pronto para continuar de onde parou.</p><div style="margin:0 0 24px;padding:18px 20px;background:#f8fafc;border:1px solid #e2e8f0;border-radius:12px;"><p style="margin:0 0 6px;font-size:13px;color:#64748b;">Produto</p><p style="margin:0 0 12px;font-size:16px;font-weight:700;color:#0f172a;">{nome_produto}</p><p style="margin:0;font-size:13px;color:#64748b;">Valor: <strong style="color:#0f172a;">{valor}</strong></p></div><p style="margin:0 0 24px;text-align:center;"><a href="{link_checkout}" style="display:inline-block;padding:15px 30px;background:#0ea5e9;color:#ffffff;text-decoration:none;font-weight:700;font-size:15px;border-radius:10px;">Continuar minha compra</a></p><p style="margin:0 0 18px;font-size:12px;line-height:1.6;color:#64748b;">Se o botão não abrir, copie e cole este endereço no navegador:<br><a href="{link_checkout}" style="color:#0284c7;word-break:break-all;">{link_checkout}</a></p><p style="margin:0;padding-top:18px;border-top:1px solid #e2e8f0;font-size:13px;line-height:1.6;color:#64748b;">Ficou com alguma dúvida? Responda este e-mail. Estamos à disposição para ajudar.</p></div>'.$shellEnd,
+            ],
+            '5h' => [
+                'subject' => 'Podemos ajudar com sua compra de {nome_produto}?',
+                'body_text' => "Olá, {nome_cliente}!\n\nNotamos que sua compra de {nome_produto} ainda não foi concluída. Se ocorreu algum problema no pagamento, você pode tentar novamente com segurança.\n\nProduto: {nome_produto}\nValor: {valor}\n\nContinuar compra:\n{link_checkout}\n\nPrecisa de ajuda? Responda este e-mail e conte o que aconteceu.",
+                'body_html' => $shellStart.'<div style="padding:32px;"><div style="display:inline-block;margin:0 0 18px;padding:7px 12px;background:#eff6ff;border-radius:999px;font-size:12px;font-weight:700;color:#2563eb;">Podemos ajudar?</div><h1 style="margin:0 0 14px;font-size:24px;line-height:1.3;color:#0f172a;">Sua compra ainda pode ser concluída</h1><p style="margin:0 0 22px;font-size:15px;line-height:1.7;color:#475569;">Olá, {nome_cliente}. Se ocorreu algum problema no pagamento, você pode tentar novamente com segurança.</p><div style="margin:0 0 24px;padding:18px;background:#f8fafc;border:1px solid #e2e8f0;border-radius:12px;"><p style="margin:0 0 5px;font-size:16px;font-weight:700;color:#0f172a;">{nome_produto}</p><p style="margin:0;font-size:14px;color:#64748b;">Valor: <strong style="color:#0f172a;">{valor}</strong></p></div><p style="margin:0 0 24px;text-align:center;"><a href="{link_checkout}" style="display:inline-block;padding:15px 30px;background:#2563eb;color:#ffffff;text-decoration:none;font-weight:700;font-size:15px;border-radius:10px;">Tentar novamente</a></p><div style="padding:18px;background:#fffbeb;border:1px solid #fde68a;border-radius:10px;"><p style="margin:0;font-size:13px;line-height:1.6;color:#92400e;"><strong>Encontrou alguma dificuldade?</strong><br>Responda este e-mail e conte o que aconteceu. Teremos prazer em ajudar.</p></div><p style="margin:18px 0 0;font-size:12px;line-height:1.6;color:#64748b;word-break:break-all;">Link alternativo: <a href="{link_checkout}" style="color:#2563eb;">{link_checkout}</a></p></div>'.$shellEnd,
+            ],
+            '24h' => [
+                'subject' => 'Seu link para {nome_produto} (caso ainda queira)',
+                'body_text' => "Olá, {nome_cliente}!\n\nEste é nosso último lembrete sobre sua compra de {nome_produto}. Caso ainda tenha interesse, seu link continua disponível abaixo.\n\nProduto: {nome_produto}\nValor: {valor}\n\nConcluir compra:\n{link_checkout}\n\nSe você já finalizou ou mudou de ideia, pode ignorar esta mensagem tranquilamente.",
+                'body_html' => $shellStart.'<div style="height:6px;background:#f59e0b;"></div><div style="padding:32px;"><p style="margin:0 0 10px;font-size:12px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:#b45309;">Último lembrete</p><h1 style="margin:0 0 14px;font-size:24px;line-height:1.3;color:#0f172a;">Seu link continua disponível</h1><p style="margin:0 0 22px;font-size:15px;line-height:1.7;color:#475569;">Olá, {nome_cliente}. Caso ainda tenha interesse em <strong>{nome_produto}</strong>, você pode concluir sua compra pelo link abaixo.</p><div style="margin:0 0 24px;padding:18px 20px;background:#fffbeb;border:1px solid #fde68a;border-radius:12px;"><p style="margin:0 0 6px;font-size:13px;color:#92400e;">Resumo da compra</p><p style="margin:0 0 8px;font-size:16px;font-weight:700;color:#78350f;">{nome_produto}</p><p style="margin:0;font-size:14px;color:#92400e;">{valor}</p></div><p style="margin:0 0 24px;text-align:center;"><a href="{link_checkout}" style="display:inline-block;padding:15px 30px;background:#f59e0b;color:#ffffff;text-decoration:none;font-weight:700;font-size:15px;border-radius:10px;">Concluir minha compra</a></p><p style="margin:0 0 18px;font-size:12px;line-height:1.6;color:#64748b;word-break:break-all;">Link alternativo: <a href="{link_checkout}" style="color:#b45309;">{link_checkout}</a></p><p style="margin:0;padding-top:18px;border-top:1px solid #e2e8f0;font-size:13px;line-height:1.6;color:#64748b;">Se você já finalizou a compra ou mudou de ideia, pode ignorar esta mensagem tranquilamente.</p></div>'.$shellEnd,
             ],
         ];
     }

--- a/app/Services/AccessEmailService.php
+++ b/app/Services/AccessEmailService.php
@@ -66,10 +66,10 @@ class AccessEmailService
             $bodyText = '';
         }
 
-        // Preferir texto simples (UI). Se vazio, cai no HTML legado.
-        if (trim($bodyText) !== '') {
+        // O editor visual salva HTML. Templates antigos em texto continuam compatíveis.
+        if (trim($bodyHtml) === '' && trim($bodyText) !== '') {
             $bodyHtml = $this->wrapAccessTextInPrettyHtml($bodyText, '{link_acesso}');
-        } elseif ($bodyHtml === '') {
+        } elseif (trim($bodyHtml) === '') {
             $bodyHtml = (string) (Product::defaultEmailTemplate()['body_html'] ?? '');
         }
 
@@ -350,9 +350,9 @@ class AccessEmailService
         $bodyText = (string) ($template['body_text'] ?? '');
         $bodyHtml = (string) ($template['body_html'] ?? '');
 
-        if (trim($bodyText) !== '') {
+        if (trim($bodyHtml) === '' && trim($bodyText) !== '') {
             $bodyHtml = $this->wrapAccessTextInPrettyHtml($bodyText, '{link_acesso}');
-        } elseif ($bodyHtml === '') {
+        } elseif (trim($bodyHtml) === '') {
             return false;
         }
 

--- a/resources/js/Pages/EmailMarketing/Create.vue
+++ b/resources/js/Pages/EmailMarketing/Create.vue
@@ -3,6 +3,7 @@ import { ref } from 'vue';
 import { Link, useForm } from '@inertiajs/vue3';
 import LayoutInfoprodutor from '@/Layouts/LayoutInfoprodutor.vue';
 import Button from '@/components/ui/Button.vue';
+import VisualEmailEditor from '@/components/email/VisualEmailEditor.vue';
 import axios from 'axios';
 
 defineOptions({ layout: LayoutInfoprodutor });
@@ -26,6 +27,10 @@ const form = useForm({
 const recipientCount = ref(null);
 const recipientSample = ref([]);
 const loadingRecipients = ref(false);
+const campaignPlaceholders = [
+    { value: '{nome}', label: 'Nome do cliente' },
+    { value: '{email}', label: 'E-mail do cliente' },
+];
 
 function useDefaultTemplate() {
     form.body_html = props.default_body_html || '';
@@ -93,15 +98,15 @@ async function previewRecipients() {
             </div>
             <div>
                 <div class="flex items-center justify-between">
-                    <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300">Corpo do e-mail (HTML)</label>
+                    <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300">Corpo do e-mail</label>
                     <Button type="button" variant="secondary" size="sm" @click="useDefaultTemplate">Usar template padrão</Button>
                 </div>
                 <p class="mt-0.5 text-xs text-zinc-500 dark:text-zinc-400">Use {nome} e {email} para personalizar.</p>
-                <textarea
+                <VisualEmailEditor
                     v-model="form.body_html"
-                    rows="14"
+                    class="mt-2"
+                    :placeholders="campaignPlaceholders"
                     required
-                    class="mt-1 block w-full rounded-lg border border-zinc-300 dark:border-zinc-600 bg-white dark:bg-zinc-900 px-3 py-2 font-mono text-sm"
                 />
                 <p v-if="form.errors.body_html" class="mt-1 text-sm text-red-600">{{ form.errors.body_html }}</p>
             </div>

--- a/resources/js/Pages/EmailMarketing/Edit.vue
+++ b/resources/js/Pages/EmailMarketing/Edit.vue
@@ -3,6 +3,7 @@ import { ref } from 'vue';
 import { Link, router, useForm } from '@inertiajs/vue3';
 import LayoutInfoprodutor from '@/Layouts/LayoutInfoprodutor.vue';
 import Button from '@/components/ui/Button.vue';
+import VisualEmailEditor from '@/components/email/VisualEmailEditor.vue';
 import axios from 'axios';
 
 defineOptions({ layout: LayoutInfoprodutor });
@@ -27,6 +28,10 @@ const form = useForm({
 const recipientCount = ref(null);
 const recipientSample = ref([]);
 const loadingRecipients = ref(false);
+const campaignPlaceholders = [
+    { value: '{nome}', label: 'Nome do cliente' },
+    { value: '{email}', label: 'E-mail do cliente' },
+];
 
 function useDefaultTemplate() {
     form.body_html = props.default_body_html || '';
@@ -103,15 +108,15 @@ function confirmSend() {
             </div>
             <div>
                 <div class="flex items-center justify-between">
-                    <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300">Corpo do e-mail (HTML)</label>
+                    <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300">Corpo do e-mail</label>
                     <Button type="button" variant="secondary" size="sm" @click="useDefaultTemplate">Usar template padrão</Button>
                 </div>
                 <p class="mt-0.5 text-xs text-zinc-500 dark:text-zinc-400">Use {nome} e {email} para personalizar.</p>
-                <textarea
+                <VisualEmailEditor
                     v-model="form.body_html"
-                    rows="14"
+                    class="mt-2"
+                    :placeholders="campaignPlaceholders"
                     required
-                    class="mt-1 block w-full rounded-lg border border-zinc-300 dark:border-zinc-600 bg-white dark:bg-zinc-900 px-3 py-2 font-mono text-sm"
                 />
                 <p v-if="form.errors.body_html" class="mt-1 text-sm text-red-600">{{ form.errors.body_html }}</p>
             </div>

--- a/resources/js/Pages/Produtos/Edit.vue
+++ b/resources/js/Pages/Produtos/Edit.vue
@@ -45,6 +45,7 @@ import {
 } from 'lucide-vue-next';
 import axios from 'axios';
 import EmailTemplatePreview from '@/components/produtos/EmailTemplatePreview.vue';
+import VisualEmailEditor from '@/components/email/VisualEmailEditor.vue';
 import ProductConversionPixelsInfo from '@/components/produtos/ProductConversionPixelsInfo.vue';
 
 function getCsrfToken() {
@@ -78,6 +79,7 @@ const DEFAULT_EMAIL_TEMPLATE = {
     subject: 'Seu acesso a {nome_produto}',
     body_text:
         'Olá, {nome_cliente}!\n\nObrigado por adquirir {nome_produto}.\n\nUse o link abaixo para acessar seu conteúdo:\n{link_acesso}\n\nQualquer dúvida, responda este e-mail.',
+    body_html: '',
 };
 
 const DEFAULT_CART_RECOVERY_EMAIL = {
@@ -122,6 +124,44 @@ const DEFAULT_SMS_CONFIG = {
 };
 
 const SMS_MAX_LENGTH = 160;
+
+const accessEmailPlaceholders = [
+    { value: '{nome_cliente}', label: 'Nome do cliente' },
+    { value: '{nome_produto}', label: 'Nome do produto' },
+    { value: '{link_acesso}', label: 'Link de acesso' },
+    { value: '{email_cliente}', label: 'E-mail do cliente' },
+    { value: '{senha}', label: 'Senha' },
+];
+
+const recoveryEmailPlaceholders = [
+    { value: '{nome_cliente}', label: 'Nome do cliente' },
+    { value: '{email_cliente}', label: 'E-mail do cliente' },
+    { value: '{nome_produto}', label: 'Nome do produto' },
+    { value: '{valor}', label: 'Valor' },
+    { value: '{link_checkout}', label: 'Link do checkout' },
+];
+
+function escapeEmailHtml(value) {
+    return String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+}
+
+function textToEmailHtml(value) {
+    return escapeEmailHtml(value)
+        .split(/\n{2,}/)
+        .filter((paragraph) => paragraph.trim())
+        .map((paragraph) => `<p style="margin:0 0 16px;font-size:15px;line-height:1.6;color:#334155;">${paragraph.replace(/\n/g, '<br>')}</p>`)
+        .join('');
+}
+
+function initialEmailHtml(template, fallback) {
+    const html = String(template?.body_html ?? '').trim();
+    return html || textToEmailHtml(template?.body_text ?? fallback?.body_text ?? '');
+}
 
 const SMS_DELAY_UNIT_OPTIONS = [
     { id: 'minutes', label: 'minutos', singular: 'minuto' },
@@ -292,6 +332,7 @@ const currentTab = computed(() => {
     const t = q.get('tab');
     return TABS.value.some((tab) => tab.id === t) ? t : 'geral';
 });
+const emailEditorTab = ref('access');
 
 function setTab(tabId) {
     router.get(`/produtos/${props.produto.id}/edit?tab=${tabId}`, {}, { preserveState: true });
@@ -354,10 +395,12 @@ const creRaw = props.produto.checkout_config?.cart_recovery_email;
 const cartRecoveryInitial = {
     ...DEFAULT_CART_RECOVERY_EMAIL,
     ...(creRaw && typeof creRaw === 'object' ? creRaw : {}),
-    stages: {
-        ...DEFAULT_CART_RECOVERY_EMAIL.stages,
-        ...(creRaw?.stages && typeof creRaw.stages === 'object' ? creRaw.stages : {}),
-    },
+    stages: Object.fromEntries(
+        Object.entries(DEFAULT_CART_RECOVERY_EMAIL.stages).map(([key, fallback]) => {
+            const stage = creRaw?.stages?.[key] && typeof creRaw.stages[key] === 'object' ? creRaw.stages[key] : {};
+            return [key, { ...fallback, ...stage, body_html: initialEmailHtml(stage, fallback) }];
+        })
+    ),
 };
 const smsRaw = props.produto.checkout_config?.sms;
 const smsInitial = {
@@ -500,6 +543,7 @@ const form = useForm({
         from_name: et.from_name ?? DEFAULT_EMAIL_TEMPLATE.from_name,
         subject: et.subject ?? DEFAULT_EMAIL_TEMPLATE.subject,
         body_text: et.body_text ?? DEFAULT_EMAIL_TEMPLATE.body_text,
+        body_html: initialEmailHtml(et, DEFAULT_EMAIL_TEMPLATE),
     },
     cart_recovery_email: cartRecoveryInitial,
     sms: smsInitial,
@@ -1454,6 +1498,20 @@ const typeIcons = {
     link_pagamento: CreditCard,
 };
 
+function buildCartRecoveryEmailPayload(value) {
+    const recovery = value && typeof value === 'object' ? value : {};
+    const stages = recovery.stages && typeof recovery.stages === 'object' ? recovery.stages : {};
+
+    return {
+        enabled: !!recovery.enabled,
+        stages: Object.fromEntries(['10m', '5h', '24h'].map((key) => [key, {
+            subject: String(stages[key]?.subject ?? ''),
+            body_text: '',
+            body_html: String(stages[key]?.body_html ?? ''),
+        }])),
+    };
+}
+
 function submit() {
     if (smsValidationError.value) {
         return;
@@ -1475,29 +1533,7 @@ function submit() {
         }
         fd.append('currency', form.currency);
         fd.append('is_active', form.is_active ? '1' : '0');
-        // Envia texto simples; o backend monta o HTML bonito automaticamente.
-        const cre = form.cart_recovery_email && typeof form.cart_recovery_email === 'object' ? form.cart_recovery_email : {};
-        const creStages = cre?.stages && typeof cre.stages === 'object' ? cre.stages : {};
-        const crePayload = {
-            enabled: !!cre.enabled,
-            stages: {
-                '10m': {
-                    subject: String(creStages?.['10m']?.subject ?? ''),
-                    body_text: String(creStages?.['10m']?.body_text ?? ''),
-                    body_html: '',
-                },
-                '5h': {
-                    subject: String(creStages?.['5h']?.subject ?? ''),
-                    body_text: String(creStages?.['5h']?.body_text ?? ''),
-                    body_html: '',
-                },
-                '24h': {
-                    subject: String(creStages?.['24h']?.subject ?? ''),
-                    body_text: String(creStages?.['24h']?.body_text ?? ''),
-                    body_html: '',
-                },
-            },
-        };
+        const crePayload = buildCartRecoveryEmailPayload(form.cart_recovery_email);
         fd.append('cart_recovery_email', JSON.stringify(crePayload));
         fd.append('sms', JSON.stringify(buildSmsPayload()));
         if (form.payment_gateways) {
@@ -1551,9 +1587,8 @@ function submit() {
             fd.append('email_template[logo_url]', form.email_template.logo_url || '');
             fd.append('email_template[from_name]', form.email_template.from_name || '');
             fd.append('email_template[subject]', form.email_template.subject || '');
-            fd.append('email_template[body_text]', form.email_template.body_text || '');
-            // Mantém compatibilidade mas evita o usuário ter que digitar HTML.
-            fd.append('email_template[body_html]', '');
+            fd.append('email_template[body_text]', '');
+            fd.append('email_template[body_html]', form.email_template.body_html || '');
         }
         fd.append('deliverable_link', form.deliverable_link || '');
         if (form.billing_type === 'subscription' && form.subscription) {
@@ -1604,6 +1639,12 @@ function submit() {
                 delete data.subscription;
             }
             data.sms = buildSmsPayload();
+            data.email_template = {
+                ...data.email_template,
+                body_text: '',
+                body_html: String(data.email_template?.body_html ?? ''),
+            };
+            data.cart_recovery_email = buildCartRecoveryEmailPayload(data.cart_recovery_email);
             return data;
         }).put(url);
     }
@@ -3061,9 +3102,28 @@ function submit() {
         <!-- Aba E-mail -->
         <template v-if="currentTab === 'email'">
             <form class="mx-auto w-full max-w-3xl space-y-8 xl:max-w-6xl" @submit.prevent="submit">
+                <div class="flex flex-col gap-2 rounded-xl border border-zinc-200 bg-zinc-50 p-1.5 dark:border-zinc-700 dark:bg-zinc-800/70 sm:flex-row">
+                    <button
+                        type="button"
+                        class="flex-1 rounded-lg px-4 py-3 text-sm font-semibold transition"
+                        :class="emailEditorTab === 'access' ? 'bg-white text-[var(--color-primary)] shadow-sm dark:bg-zinc-700' : 'text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-white'"
+                        @click="emailEditorTab = 'access'"
+                    >
+                        Template do e-mail de acesso
+                    </button>
+                    <button
+                        type="button"
+                        class="flex flex-1 items-center justify-center gap-2 rounded-lg px-4 py-3 text-sm font-semibold transition"
+                        :class="emailEditorTab === 'recovery' ? 'bg-white text-[var(--color-primary)] shadow-sm dark:bg-zinc-700' : 'text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-white'"
+                        @click="emailEditorTab = 'recovery'"
+                    >
+                        Template de recuperação
+                        <span v-if="form.cart_recovery_email.enabled" class="h-2 w-2 rounded-full bg-emerald-500" title="Recuperação ativa" />
+                    </button>
+                </div>
                 <div class="grid grid-cols-1 gap-8 xl:grid-cols-2">
                     <!-- Configuração do template -->
-                    <section class="panel-table">
+                    <section v-if="emailEditorTab === 'access'" class="panel-table xl:col-span-2">
                         <div class="border-b border-zinc-200/80 bg-gradient-to-r from-zinc-50/90 to-zinc-100/50 px-6 py-5 dark:from-zinc-800/80 dark:to-zinc-800/50">
                             <h2 class="text-base font-semibold text-zinc-900 dark:text-white">Template do e-mail de acesso</h2>
                             <p class="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
@@ -3106,8 +3166,12 @@ function submit() {
                                 <input v-model="form.email_template.subject" type="text" placeholder="Seu acesso a {nome_produto}" :class="inputClass" />
                             </div>
                             <div>
-                                <label class="mb-1.5 block text-sm font-medium text-zinc-700 dark:text-zinc-300">Mensagem (texto)</label>
-                                <textarea v-model="form.email_template.body_text" rows="14" :class="inputClass" placeholder="Digite a mensagem (texto simples)..." />
+                                <label class="mb-1.5 block text-sm font-medium text-zinc-700 dark:text-zinc-300">Mensagem</label>
+                                <VisualEmailEditor
+                                    v-model="form.email_template.body_html"
+                                    :placeholders="accessEmailPlaceholders"
+                                    min-height="360px"
+                                />
                                 <p class="mt-1.5 text-xs text-zinc-500 dark:text-zinc-400">
                                     Placeholders: <code class="rounded bg-zinc-100 px-1 dark:bg-zinc-700">{nome_cliente}</code>,
                                     <code class="rounded bg-zinc-100 px-1 dark:bg-zinc-700">{nome_produto}</code>,
@@ -3121,7 +3185,7 @@ function submit() {
                     </section>
 
                     <!-- Recuperação de carrinho -->
-                    <section class="panel-table">
+                    <section v-if="emailEditorTab === 'recovery'" class="panel-table xl:col-span-2">
                         <div class="border-b border-zinc-200/80 bg-gradient-to-r from-zinc-50/90 to-zinc-100/50 px-6 py-5 dark:from-zinc-800/80 dark:to-zinc-800/50">
                             <div class="flex items-start justify-between gap-4">
                                 <div>
@@ -3152,8 +3216,8 @@ function submit() {
                                     <input v-model="form.cart_recovery_email.stages['10m'].subject" :disabled="!form.cart_recovery_email.enabled" type="text" :class="inputClass" placeholder="Você ainda quer garantir {nome_produto}?" />
                                 </div>
                                 <div>
-                                    <label class="mb-1.5 block text-sm font-medium text-zinc-700 dark:text-zinc-300">Mensagem (texto)</label>
-                                    <textarea v-model="form.cart_recovery_email.stages['10m'].body_text" :disabled="!form.cart_recovery_email.enabled" rows="10" :class="inputClass" placeholder="Digite a mensagem (texto simples)..." />
+                                    <label class="mb-1.5 block text-sm font-medium text-zinc-700 dark:text-zinc-300">Mensagem</label>
+                                    <VisualEmailEditor v-model="form.cart_recovery_email.stages['10m'].body_html" :disabled="!form.cart_recovery_email.enabled" :placeholders="recoveryEmailPlaceholders" min-height="240px" />
                                 </div>
                             </div>
 
@@ -3166,8 +3230,8 @@ function submit() {
                                     <input v-model="form.cart_recovery_email.stages['5h'].subject" :disabled="!form.cart_recovery_email.enabled" type="text" :class="inputClass" placeholder="Última chance de garantir {nome_produto}" />
                                 </div>
                                 <div>
-                                    <label class="mb-1.5 block text-sm font-medium text-zinc-700 dark:text-zinc-300">Mensagem (texto)</label>
-                                    <textarea v-model="form.cart_recovery_email.stages['5h'].body_text" :disabled="!form.cart_recovery_email.enabled" rows="10" :class="inputClass" placeholder="Digite a mensagem (texto simples)..." />
+                                    <label class="mb-1.5 block text-sm font-medium text-zinc-700 dark:text-zinc-300">Mensagem</label>
+                                    <VisualEmailEditor v-model="form.cart_recovery_email.stages['5h'].body_html" :disabled="!form.cart_recovery_email.enabled" :placeholders="recoveryEmailPlaceholders" min-height="240px" />
                                 </div>
                             </div>
 
@@ -3180,15 +3244,15 @@ function submit() {
                                     <input v-model="form.cart_recovery_email.stages['24h'].subject" :disabled="!form.cart_recovery_email.enabled" type="text" :class="inputClass" placeholder="Seu link para {nome_produto} (caso ainda queira)" />
                                 </div>
                                 <div>
-                                    <label class="mb-1.5 block text-sm font-medium text-zinc-700 dark:text-zinc-300">Mensagem (texto)</label>
-                                    <textarea v-model="form.cart_recovery_email.stages['24h'].body_text" :disabled="!form.cart_recovery_email.enabled" rows="10" :class="inputClass" placeholder="Digite a mensagem (texto simples)..." />
+                                    <label class="mb-1.5 block text-sm font-medium text-zinc-700 dark:text-zinc-300">Mensagem</label>
+                                    <VisualEmailEditor v-model="form.cart_recovery_email.stages['24h'].body_html" :disabled="!form.cart_recovery_email.enabled" :placeholders="recoveryEmailPlaceholders" min-height="240px" />
                                 </div>
                             </div>
                         </div>
                     </section>
 
                     <!-- Preview do e-mail -->
-                    <section class="panel-table xl:sticky xl:top-6">
+                    <section v-if="emailEditorTab === 'access'" class="panel-table xl:col-span-2">
                         <div class="border-b border-zinc-200/80 bg-zinc-50/80 px-6 py-4 dark:border-zinc-700/80 dark:bg-zinc-800/50">
                             <h2 class="text-base font-semibold text-zinc-900 dark:text-white">Preview do e-mail</h2>
                             <p class="mt-0.5 text-sm text-zinc-500 dark:text-zinc-400">Como o e-mail será exibido para o cliente.</p>
@@ -3197,7 +3261,7 @@ function submit() {
                             <EmailTemplatePreview
                                 :logo-url="form.email_template.logo_url"
                                 :subject="form.email_template.subject"
-                                :body-html="(form.email_template.body_text || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').split('\\n\\n').filter((p) => p.trim()).map((p) => `<p style=&quot;margin:0 0 16px;font-size:15px;line-height:1.6;color:#334155;&quot;>${p.replace(/\\n/g, '<br/>')}</p>`).join('')"
+                                :body-html="form.email_template.body_html"
                                 :from-name="form.email_template.from_name"
                             />
                         </div>

--- a/resources/js/Pages/Produtos/Edit.vue
+++ b/resources/js/Pages/Produtos/Edit.vue
@@ -88,17 +88,17 @@ const DEFAULT_CART_RECOVERY_EMAIL = {
         '10m': {
             subject: 'Você ainda quer garantir {nome_produto}?',
             body_text:
-                'Olá, {nome_cliente}!\n\nPercebi que você iniciou sua compra de {nome_produto} e não concluiu.\n\nSe ainda faz sentido pra você, é só retomar pelo link abaixo:\n{link_checkout}\n\nSe precisar de ajuda, é só responder este e-mail.',
+                'Olá, {nome_cliente}!\n\nVocê estava a poucos passos de concluir sua compra de {nome_produto}. Deixamos tudo pronto para você continuar de onde parou.\n\nProduto: {nome_produto}\nValor: {valor}\n\nRetome sua compra com segurança:\n{link_checkout}\n\nSe tiver alguma dúvida, responda este e-mail. Estamos à disposição para ajudar.',
         },
         '5h': {
-            subject: 'Última chance de garantir {nome_produto}',
+            subject: 'Podemos ajudar com sua compra de {nome_produto}?',
             body_text:
-                '{nome_cliente}, posso te ajudar?\n\nSua compra de {nome_produto} ainda não foi finalizada.\n\nPara concluir agora, use este link:\n{link_checkout}\n\nSe teve algum erro no pagamento, basta tentar novamente pelo link.',
+                'Olá, {nome_cliente}!\n\nNotamos que sua compra de {nome_produto} ainda não foi concluída. Se ocorreu algum problema no pagamento, você pode tentar novamente com segurança.\n\nProduto: {nome_produto}\nValor: {valor}\n\nContinuar compra:\n{link_checkout}\n\nPrecisa de ajuda? Responda este e-mail e conte o que aconteceu.',
         },
         '24h': {
             subject: 'Seu link para {nome_produto} (caso ainda queira)',
             body_text:
-                'Último lembrete.\n\nDeixando aqui seu link para concluir a compra de {nome_produto} quando for melhor:\n{link_checkout}\n\nSe você já concluiu, pode ignorar este e-mail.',
+                'Olá, {nome_cliente}!\n\nEste é nosso último lembrete sobre sua compra de {nome_produto}. Caso ainda tenha interesse, seu link continua disponível abaixo.\n\nProduto: {nome_produto}\nValor: {valor}\n\nConcluir compra:\n{link_checkout}\n\nSe você já finalizou ou mudou de ideia, pode ignorar esta mensagem tranquilamente.',
         },
     },
 };
@@ -286,6 +286,7 @@ const BASE_TABS = [
 
 const props = defineProps({
     produto: { type: Object, required: true },
+    default_cart_recovery_email: { type: Object, default: () => ({ stages: {} }) },
     productTypes: { type: Array, default: () => [] },
     billingTypes: { type: Array, default: () => [] },
     exchange_rates: { type: Object, default: () => ({ brl_eur: 0.16, brl_usd: 0.18 }) },
@@ -1509,6 +1510,22 @@ function buildCartRecoveryEmailPayload(value) {
             body_text: '',
             body_html: String(stages[key]?.body_html ?? ''),
         }])),
+    };
+}
+
+function restoreDefaultRecoveryLayout(stageKey) {
+    const defaultStage = props.default_cart_recovery_email?.stages?.[stageKey];
+    if (!defaultStage) return;
+    const confirmed = window.confirm(
+        'Usar o layout padrão?\n\nO assunto e todo o conteúdo atual desta etapa serão substituídos. Essa ação só poderá ser desfeita antes de salvar a página.',
+    );
+    if (!confirmed) return;
+
+    form.cart_recovery_email.stages[stageKey] = {
+        ...form.cart_recovery_email.stages[stageKey],
+        subject: defaultStage.subject || '',
+        body_text: defaultStage.body_text || '',
+        body_html: defaultStage.body_html || '',
     };
 }
 
@@ -3210,6 +3227,7 @@ function submit() {
                             <div class="panel-card-sm space-y-3 dark:bg-zinc-900/20">
                                 <div class="flex items-center justify-between gap-3">
                                     <h3 class="text-sm font-semibold text-zinc-900 dark:text-white">Etapa 1 — 10 minutos</h3>
+                                    <button type="button" class="rounded-lg border border-zinc-300 bg-white px-3 py-1.5 text-xs font-medium text-zinc-700 transition hover:border-[var(--color-primary)] hover:text-[var(--color-primary)] dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-200" @click="restoreDefaultRecoveryLayout('10m')">Usar layout padrão</button>
                                 </div>
                                 <div>
                                     <label class="mb-1.5 block text-sm font-medium text-zinc-700 dark:text-zinc-300">Assunto</label>
@@ -3224,6 +3242,7 @@ function submit() {
                             <div class="panel-card-sm space-y-3 dark:bg-zinc-900/20">
                                 <div class="flex items-center justify-between gap-3">
                                     <h3 class="text-sm font-semibold text-zinc-900 dark:text-white">Etapa 2 — 5 horas</h3>
+                                    <button type="button" class="rounded-lg border border-zinc-300 bg-white px-3 py-1.5 text-xs font-medium text-zinc-700 transition hover:border-[var(--color-primary)] hover:text-[var(--color-primary)] dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-200" @click="restoreDefaultRecoveryLayout('5h')">Usar layout padrão</button>
                                 </div>
                                 <div>
                                     <label class="mb-1.5 block text-sm font-medium text-zinc-700 dark:text-zinc-300">Assunto</label>
@@ -3238,6 +3257,7 @@ function submit() {
                             <div class="panel-card-sm space-y-3 dark:bg-zinc-900/20">
                                 <div class="flex items-center justify-between gap-3">
                                     <h3 class="text-sm font-semibold text-zinc-900 dark:text-white">Etapa 3 — 24 horas</h3>
+                                    <button type="button" class="rounded-lg border border-zinc-300 bg-white px-3 py-1.5 text-xs font-medium text-zinc-700 transition hover:border-[var(--color-primary)] hover:text-[var(--color-primary)] dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-200" @click="restoreDefaultRecoveryLayout('24h')">Usar layout padrão</button>
                                 </div>
                                 <div>
                                     <label class="mb-1.5 block text-sm font-medium text-zinc-700 dark:text-zinc-300">Assunto</label>

--- a/resources/js/components/email/VisualEmailEditor.vue
+++ b/resources/js/components/email/VisualEmailEditor.vue
@@ -1,0 +1,786 @@
+<script setup>
+import { nextTick, onMounted, reactive, ref, watch } from 'vue';
+import {
+    AlignCenter,
+    AlignLeft,
+    AlignRight,
+    Bold,
+    Code2,
+    Italic,
+    Link,
+    List,
+    ListOrdered,
+    Pilcrow,
+    Redo2,
+    RemoveFormatting,
+    Underline,
+    Undo2,
+    Unlink,
+} from 'lucide-vue-next';
+
+const props = defineProps({
+    modelValue: { type: String, default: '' },
+    disabled: { type: Boolean, default: false },
+    placeholders: { type: Array, default: () => [] },
+    minHeight: { type: String, default: '320px' },
+    required: { type: Boolean, default: false },
+});
+
+const emit = defineEmits(['update:modelValue']);
+
+const editor = ref(null);
+const sourceMode = ref(false);
+const previewMode = ref('desktop');
+const savedRange = ref(null);
+const undoStack = ref([]);
+const redoStack = ref([]);
+const restoringHistory = ref(false);
+const selectedPlaceholder = ref('');
+const selectedButton = ref(null);
+const selectedElement = ref(null);
+const selectedType = ref('');
+const buttonColor = ref('#0ea5e9');
+const textColor = ref('#334155');
+const backgroundColor = ref('#f8fafc');
+const contentBackgroundColor = ref('#ffffff');
+const typographySettings = reactive({
+    fontFamily: 'Arial, sans-serif',
+    fontSize: 15,
+    lineHeight: 1.6,
+    color: '#334155',
+});
+const buttonSettings = reactive({
+    text: '',
+    url: '',
+    backgroundColor: '#0ea5e9',
+    textColor: '#ffffff',
+    borderRadius: 8,
+    alignment: 'center',
+    fullWidth: false,
+});
+const linkSettings = reactive({ text: '', url: '', color: '#0284c7' });
+const imageSettings = reactive({
+    url: '',
+    alt: '',
+    link: '',
+    width: 600,
+    borderRadius: 0,
+    alignment: 'center',
+});
+const blockLibrary = [
+    { type: 'hero', label: 'Hero' },
+    { type: 'title', label: 'Título' },
+    { type: 'text', label: 'Texto' },
+    { type: 'button', label: 'Botão' },
+    { type: 'image', label: 'Imagem' },
+    { type: 'content', label: 'Seção' },
+    { type: 'columns', label: '2 colunas' },
+    { type: 'product', label: 'Produto' },
+    { type: 'coupon', label: 'Cupom' },
+    { type: 'benefits', label: 'Benefícios' },
+    { type: 'testimonial', label: 'Depoimento' },
+    { type: 'social', label: 'Social' },
+    { type: 'divider', label: 'Divisor' },
+    { type: 'spacer', label: 'Espaço' },
+    { type: 'footer', label: 'Rodapé' },
+];
+
+function syncEditor() {
+    if (!editor.value || sourceMode.value || editor.value.innerHTML === props.modelValue) return;
+    editor.value.innerHTML = props.modelValue || '';
+    normalizeLegacyElements();
+    syncGeneralColors();
+    selectedButton.value = null;
+    clearSelection();
+}
+
+function normalizeLegacyElements() {
+    if (!editor.value) return;
+    editor.value.querySelectorAll('a').forEach((link) => {
+        const style = link.style;
+        const looksLikeButton = style.backgroundColor || style.padding || style.display === 'inline-block' || style.borderRadius;
+        if (looksLikeButton) {
+            link.dataset.emailButton = 'true';
+            const container = link.parentElement;
+            if (container) container.dataset.emailButtonContainer = 'true';
+        } else if (!link.dataset.emailLink) {
+            link.dataset.emailLink = 'true';
+        }
+    });
+}
+
+function emitVisualValue() {
+    if (!editor.value) return;
+    const value = editor.value.innerHTML === '<br>' ? '' : editor.value.innerHTML;
+    emit('update:modelValue', value);
+}
+
+function recordHistory() {
+    if (!editor.value || restoringHistory.value) return;
+    const snapshot = editor.value.innerHTML;
+    if (undoStack.value.at(-1) !== snapshot) {
+        undoStack.value.push(snapshot);
+        if (undoStack.value.length > 60) undoStack.value.shift();
+    }
+    redoStack.value = [];
+}
+
+function restoreHistorySnapshot(snapshot) {
+    if (!editor.value) return;
+    restoringHistory.value = true;
+    editor.value.innerHTML = snapshot;
+    normalizeLegacyElements();
+    syncGeneralColors();
+    clearSelection();
+    emitVisualValue();
+    restoringHistory.value = false;
+}
+
+function undoEditor() {
+    if (!editor.value) return;
+    const snapshot = undoStack.value.pop();
+    if (snapshot === undefined) {
+        run('undo');
+        return;
+    }
+    redoStack.value.push(editor.value.innerHTML);
+    restoreHistorySnapshot(snapshot);
+}
+
+function redoEditor() {
+    if (!editor.value) return;
+    const snapshot = redoStack.value.pop();
+    if (snapshot === undefined) {
+        run('redo');
+        return;
+    }
+    undoStack.value.push(editor.value.innerHTML);
+    restoreHistorySnapshot(snapshot);
+}
+
+function rememberSelection() {
+    if (!editor.value) return;
+    const selection = window.getSelection();
+    if (!selection?.rangeCount) return;
+    const range = selection.getRangeAt(0);
+    if (editor.value.contains(range.commonAncestorContainer)) {
+        savedRange.value = range.cloneRange();
+    }
+}
+
+function restoreSelection() {
+    if (!editor.value) return;
+    const selection = window.getSelection();
+    if (!selection) return;
+    let range = savedRange.value;
+    if (!range || !editor.value.contains(range.commonAncestorContainer)) {
+        range = document.createRange();
+        range.selectNodeContents(editor.value);
+        range.collapse(false);
+    }
+    selection.removeAllRanges();
+    selection.addRange(range);
+}
+
+function run(command, value = null) {
+    if (props.disabled || sourceMode.value) return;
+    if (command !== 'undo' && command !== 'redo') recordHistory();
+    editor.value?.focus();
+    restoreSelection();
+    document.execCommand(command, false, value);
+    rememberSelection();
+    emitVisualValue();
+}
+
+function setBlock(tag) {
+    if (props.disabled || sourceMode.value || !editor.value) return;
+    recordHistory();
+    restoreSelection();
+
+    const selection = window.getSelection();
+    if (!selection?.rangeCount) return;
+    const range = selection.getRangeAt(0);
+    const selector = 'p, h1, h2, h3';
+    const candidates = Array.from(editor.value.querySelectorAll(selector)).filter((element) => {
+        try {
+            return range.intersectsNode(element);
+        } catch (_) {
+            return false;
+        }
+    });
+
+    let blocks = candidates.filter((element) => !candidates.some((other) => other !== element && other.contains(element)));
+    if (!blocks.length) {
+        const container = range.commonAncestorContainer.nodeType === Node.ELEMENT_NODE
+            ? range.commonAncestorContainer
+            : range.commonAncestorContainer.parentElement;
+        const current = container?.closest?.(selector);
+        if (current && editor.value.contains(current)) blocks = [current];
+    }
+
+    if (!blocks.length) {
+        document.execCommand('formatBlock', false, `<${tag}>`);
+        rememberSelection();
+        emitVisualValue();
+        return;
+    }
+
+    let lastReplacement = null;
+    blocks.forEach((block) => {
+        if (block.tagName.toLowerCase() === tag) return;
+        const replacement = document.createElement(tag);
+        Array.from(block.attributes).forEach((attribute) => replacement.setAttribute(attribute.name, attribute.value));
+        replacement.innerHTML = block.innerHTML;
+        replacement.style.removeProperty('font-size');
+        replacement.style.removeProperty('font-weight');
+        replacement.style.removeProperty('line-height');
+        block.replaceWith(replacement);
+        lastReplacement = replacement;
+    });
+
+    if (lastReplacement) {
+        const nextRange = document.createRange();
+        nextRange.selectNodeContents(lastReplacement);
+        selection.removeAllRanges();
+        selection.addRange(nextRange);
+        savedRange.value = nextRange.cloneRange();
+    }
+    emitVisualValue();
+}
+
+function createLink() {
+    if (props.disabled || sourceMode.value) return;
+    const id = createEditorId('link');
+    run('insertHTML', `<a data-email-link="true" data-editor-id="${id}" href="#" style="color:#0284c7;text-decoration:underline;">Editar link</a>`);
+    selectInsertedElement(id, 'link');
+}
+
+function insertButton() {
+    const id = createEditorId('button');
+    run('insertHTML', `<div data-email-block="true" data-email-block-type="button"><p data-email-button-container="true" style="margin:24px 0;text-align:center;"><a data-email-button="true" data-editor-id="${id}" href="#" style="display:inline-block;padding:14px 28px;background-color:${buttonColor.value};color:#ffffff;text-decoration:none;font-weight:700;border-radius:8px;">Clique aqui</a></p></div>`);
+    selectInsertedElement(id, 'button');
+}
+
+function insertImage() {
+    const id = createEditorId('image');
+    run('insertHTML', `<div data-email-block="true" data-email-block-type="image"><div data-email-image-block="true" data-editor-id="${id}" style="margin:20px 0;text-align:center;"><div data-email-image-placeholder="true" style="padding:40px 20px;border:2px dashed #cbd5e1;border-radius:8px;color:#64748b;background:#f8fafc;">Informe a URL da imagem no painel de propriedades</div><img data-email-image="true" src="" alt="" style="display:none;max-width:100%;height:auto;margin:0 auto;border:0;border-radius:0;" /></div></div>`);
+    selectInsertedElement(id, 'image');
+}
+
+function createEditorId(prefix) {
+    return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+}
+
+async function selectInsertedElement(id, type) {
+    await nextTick();
+    const element = editor.value?.querySelector(`[data-editor-id="${id}"]`);
+    if (element) selectElement(element, type);
+}
+
+function wrapPreset(type, html) {
+    const id = createEditorId(type);
+    return `<div data-email-block="true" data-email-block-type="${type}" data-editor-id="${id}" style="position:relative;">${html}</div>`;
+}
+
+function insertPreset(value) {
+    const preset = typeof value === 'string' ? value : value.target.value;
+    if (typeof value !== 'string') value.target.value = '';
+    if (!preset || props.disabled) return;
+
+    if (preset === 'button') return insertButton();
+    if (preset === 'image') return insertImage();
+    if (preset === 'title') return run('insertHTML', wrapPreset('title', '<h2 style="margin:0 0 16px;font-size:26px;line-height:1.25;color:#0f172a;">Título do e-mail</h2>'));
+    if (preset === 'text') return run('insertHTML', wrapPreset('text', '<p style="margin:0 0 16px;font-size:15px;line-height:1.6;color:#334155;">Digite aqui o conteúdo da sua mensagem.</p>'));
+    if (preset === 'content') {
+        return run('insertHTML', wrapPreset('content', '<div style="margin:20px 0;padding:24px;background:#ffffff;border:1px solid #e2e8f0;border-radius:12px;"><h2 style="margin:0 0 12px;font-size:22px;line-height:1.3;color:#0f172a;">Título da seção</h2><p style="margin:0;font-size:15px;line-height:1.6;color:#334155;">Adicione aqui o conteúdo da sua mensagem.</p></div>'));
+    }
+    if (preset === 'hero') return run('insertHTML', wrapPreset('hero', `<div style="padding:40px 28px;text-align:center;background:#eff6ff;border-radius:16px;"><p style="margin:0 0 8px;font-size:13px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:#0284c7;">Novidade</p><h1 style="margin:0 0 16px;font-size:32px;line-height:1.2;color:#0f172a;">Uma mensagem que chama atenção</h1><p style="margin:0 auto 24px;max-width:480px;font-size:16px;line-height:1.6;color:#475569;">Explique o principal benefício da sua oferta de forma clara.</p><p data-email-button-container="true" style="margin:0;text-align:center;"><a data-email-button="true" href="#" style="display:inline-block;padding:14px 28px;background-color:${buttonColor.value};color:#ffffff;text-decoration:none;font-weight:700;border-radius:8px;">Conhecer oferta</a></p></div>`));
+    if (preset === 'columns') return run('insertHTML', wrapPreset('columns', '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td width="50%" valign="top" style="padding:12px;"><h3 style="margin:0 0 8px;color:#0f172a;">Primeira coluna</h3><p style="margin:0;color:#475569;line-height:1.6;">Adicione seu conteúdo.</p></td><td width="50%" valign="top" style="padding:12px;"><h3 style="margin:0 0 8px;color:#0f172a;">Segunda coluna</h3><p style="margin:0;color:#475569;line-height:1.6;">Adicione seu conteúdo.</p></td></tr></table>'));
+    if (preset === 'product') return run('insertHTML', wrapPreset('product', `<div style="padding:24px;text-align:center;border:1px solid #e2e8f0;border-radius:12px;background:#ffffff;"><h2 style="margin:0 0 8px;color:#0f172a;">Nome do produto</h2><p style="margin:0 0 8px;color:#64748b;">Descrição curta do produto</p><p style="margin:0 0 20px;font-size:24px;font-weight:700;color:#0f172a;">R$ 00,00</p><p data-email-button-container="true" style="margin:0;text-align:center;"><a data-email-button="true" href="#" style="display:inline-block;padding:14px 28px;background-color:${buttonColor.value};color:#ffffff;text-decoration:none;font-weight:700;border-radius:8px;">Comprar agora</a></p></div>`));
+    if (preset === 'coupon') return run('insertHTML', wrapPreset('coupon', '<div style="margin:20px 0;padding:24px;text-align:center;background:#fffbeb;border:2px dashed #f59e0b;border-radius:12px;"><p style="margin:0 0 8px;color:#92400e;">Use o cupom</p><p style="margin:0;font-size:28px;font-weight:800;letter-spacing:.12em;color:#78350f;">DESCONTO10</p></div>'));
+    if (preset === 'benefits') return run('insertHTML', wrapPreset('benefits', '<div style="margin:20px 0;padding:24px;background:#f8fafc;border-radius:12px;"><h2 style="margin:0 0 16px;color:#0f172a;">Você vai receber</h2><p style="margin:0 0 10px;color:#334155;">✓ Primeiro benefício importante</p><p style="margin:0 0 10px;color:#334155;">✓ Segundo benefício importante</p><p style="margin:0;color:#334155;">✓ Terceiro benefício importante</p></div>'));
+    if (preset === 'testimonial') return run('insertHTML', wrapPreset('testimonial', '<blockquote style="margin:20px 0;padding:24px;border-left:4px solid #0ea5e9;background:#f8fafc;color:#334155;font-size:16px;line-height:1.6;"><p style="margin:0 0 12px;">“Escreva aqui um depoimento de cliente.”</p><footer style="font-size:13px;font-weight:700;color:#64748b;">— Nome do cliente</footer></blockquote>'));
+    if (preset === 'social') return run('insertHTML', wrapPreset('social', '<p style="margin:24px 0;text-align:center;"><a data-email-link="true" href="#" style="margin:0 8px;color:#0284c7;">Instagram</a><a data-email-link="true" href="#" style="margin:0 8px;color:#0284c7;">YouTube</a><a data-email-link="true" href="#" style="margin:0 8px;color:#0284c7;">Site</a></p>'));
+    if (preset === 'footer') return run('insertHTML', wrapPreset('footer', '<div style="padding:24px;text-align:center;background:#f1f5f9;color:#64748b;font-size:12px;line-height:1.6;"><p style="margin:0 0 8px;">Você recebeu este e-mail porque possui relacionamento com nossa empresa.</p><p style="margin:0;">© Sua marca</p></div>'));
+    if (preset === 'divider') return run('insertHTML', wrapPreset('divider', '<hr style="margin:24px 0;border:0;border-top:1px solid #e2e8f0;" />'));
+    if (preset === 'spacer') return run('insertHTML', wrapPreset('spacer', '<div data-email-spacer="true" style="height:32px;line-height:32px;font-size:1px;">&nbsp;</div>'));
+}
+
+function selectEditableElement(event) {
+    const clickedLink = event.target.closest?.('a');
+    const button = clickedLink && (clickedLink.dataset.emailButton === 'true' || clickedLink.style.backgroundColor || clickedLink.style.padding)
+        ? clickedLink
+        : null;
+    if (button) return selectElement(button, 'button');
+    const image = event.target.closest?.('[data-email-image-block="true"], img');
+    if (image) return selectElement(image, 'image');
+    const link = clickedLink;
+    if (link) return selectElement(link, 'link');
+    const block = event.target.closest?.('[data-email-block="true"]');
+    if (block) return selectElement(block, 'block');
+    clearSelection();
+}
+
+function colorToHex(value, fallback) {
+    if (!value) return fallback;
+    if (value.startsWith('#')) return value.length === 4
+        ? `#${value[1]}${value[1]}${value[2]}${value[2]}${value[3]}${value[3]}`
+        : value.slice(0, 7);
+    const rgb = value.match(/\d+/g)?.map(Number);
+    return rgb?.length >= 3
+        ? `#${rgb.slice(0, 3).map((part) => part.toString(16).padStart(2, '0')).join('')}`
+        : fallback;
+}
+
+function selectElement(element, type) {
+    selectedElement.value = element;
+    selectedType.value = type;
+
+    if (type === 'button') {
+        selectedButton.value = element;
+        const container = element.closest('[data-email-button-container="true"]') || element.parentElement;
+        element.dataset.emailButton = 'true';
+        if (container) container.dataset.emailButtonContainer = 'true';
+        Object.assign(buttonSettings, {
+            text: element.textContent || '',
+            url: element.getAttribute('href') || '',
+            backgroundColor: colorToHex(element.style.backgroundColor, '#0ea5e9'),
+            textColor: colorToHex(element.style.color, '#ffffff'),
+            borderRadius: parseInt(element.style.borderRadius, 10) || 0,
+            alignment: container?.style.textAlign || 'center',
+            fullWidth: element.style.width === '100%',
+        });
+        buttonColor.value = buttonSettings.backgroundColor;
+    } else if (type === 'link') {
+        Object.assign(linkSettings, {
+            text: element.textContent || '',
+            url: element.getAttribute('href') || '',
+            color: colorToHex(element.style.color, '#0284c7'),
+        });
+    } else if (type === 'image') {
+        const image = element.matches?.('img') ? element : element.querySelector('[data-email-image="true"], img');
+        const linkedImage = image?.closest('a');
+        image?.setAttribute('data-email-image', 'true');
+        Object.assign(imageSettings, {
+            url: image?.getAttribute('src') || '',
+            alt: image?.getAttribute('alt') || '',
+            link: linkedImage?.getAttribute('href') || '',
+            width: parseInt(image?.style.width, 10) || 600,
+            borderRadius: parseInt(image?.style.borderRadius, 10) || 0,
+            alignment: (element.matches?.('img') ? element.parentElement : element)?.style.textAlign || 'center',
+        });
+    }
+}
+
+function clearSelection() {
+    selectedElement.value = null;
+    selectedButton.value = null;
+    selectedType.value = '';
+}
+
+function updateButtonColor(event) {
+    recordHistory();
+    buttonColor.value = event.target.value;
+    if (!selectedButton.value) return;
+    selectedButton.value.style.backgroundColor = buttonColor.value;
+    buttonSettings.backgroundColor = buttonColor.value;
+    emitVisualValue();
+}
+
+function updateSelectedButton() {
+    const button = selectedElement.value;
+    if (!button || selectedType.value !== 'button') return;
+    recordHistory();
+    const container = button.closest('[data-email-button-container="true"]') || button.parentElement;
+    button.textContent = buttonSettings.text || 'Botão';
+    button.setAttribute('href', buttonSettings.url || '#');
+    button.style.backgroundColor = buttonSettings.backgroundColor;
+    button.style.color = buttonSettings.textColor;
+    button.style.borderRadius = `${buttonSettings.borderRadius}px`;
+    button.style.display = buttonSettings.fullWidth ? 'block' : 'inline-block';
+    button.style.width = buttonSettings.fullWidth ? '100%' : 'auto';
+    button.style.boxSizing = 'border-box';
+    if (container) container.style.textAlign = buttonSettings.alignment;
+    buttonColor.value = buttonSettings.backgroundColor;
+    emitVisualValue();
+}
+
+function updateSelectedLink() {
+    const link = selectedElement.value;
+    if (!link || selectedType.value !== 'link') return;
+    recordHistory();
+    link.textContent = linkSettings.text || 'Link';
+    link.setAttribute('href', linkSettings.url || '#');
+    link.style.color = linkSettings.color;
+    emitVisualValue();
+}
+
+function updateSelectedImage() {
+    const selected = selectedElement.value;
+    if (!selected || selectedType.value !== 'image') return;
+    recordHistory();
+    const image = selected.matches?.('img') ? selected : selected.querySelector('[data-email-image="true"], img');
+    const block = selected.matches?.('img') ? selected.parentElement : selected;
+    const placeholder = block?.querySelector?.('[data-email-image-placeholder="true"]');
+    if (!image || !block) return;
+    let anchor = image?.closest('a');
+
+    image.setAttribute('src', imageSettings.url || '');
+    image.setAttribute('alt', imageSettings.alt || '');
+    image.style.display = imageSettings.url ? 'block' : 'none';
+    image.style.width = `${Math.max(40, Number(imageSettings.width) || 600)}px`;
+    image.style.maxWidth = '100%';
+    image.style.borderRadius = `${imageSettings.borderRadius}px`;
+    block.style.textAlign = imageSettings.alignment;
+    image.style.margin = imageSettings.alignment === 'left' ? '0 auto 0 0' : imageSettings.alignment === 'right' ? '0 0 0 auto' : '0 auto';
+    if (placeholder) placeholder.style.display = imageSettings.url ? 'none' : 'block';
+
+    if (imageSettings.link && !anchor) {
+        anchor = document.createElement('a');
+        image.replaceWith(anchor);
+        anchor.appendChild(image);
+    }
+    if (anchor) {
+        if (imageSettings.link) anchor.setAttribute('href', imageSettings.link);
+        else anchor.replaceWith(image);
+    }
+    emitVisualValue();
+}
+
+function removeSelectedElement() {
+    if (!selectedElement.value) return;
+    recordHistory();
+    const target = selectedType.value === 'button'
+        ? (selectedElement.value.closest('[data-email-button-container="true"]') || selectedElement.value)
+        : selectedType.value === 'image'
+            ? (selectedElement.value.closest?.('[data-email-block-type="image"]') || selectedElement.value)
+            : selectedElement.value;
+    target.remove();
+    clearSelection();
+    emitVisualValue();
+}
+
+function selectedBlockRoot() {
+    if (!selectedElement.value) return null;
+    if (selectedType.value === 'button') {
+        return selectedElement.value.closest('[data-email-block="true"], [data-email-button-container="true"]') || selectedElement.value;
+    }
+    return selectedElement.value.closest?.('[data-email-block="true"]') || selectedElement.value;
+}
+
+function duplicateSelectedElement() {
+    const target = selectedBlockRoot();
+    if (!target) return;
+    recordHistory();
+    const clone = target.cloneNode(true);
+    clone.querySelectorAll?.('[data-editor-id]').forEach((item) => item.removeAttribute('data-editor-id'));
+    clone.removeAttribute?.('data-editor-id');
+    target.after(clone);
+    selectElement(clone, clone.dataset.emailBlock ? 'block' : selectedType.value);
+    emitVisualValue();
+}
+
+function moveSelectedElement(direction) {
+    const target = selectedBlockRoot();
+    if (!target) return;
+    recordHistory();
+    if (direction === 'up' && target.previousElementSibling) {
+        target.parentElement.insertBefore(target, target.previousElementSibling);
+    } else if (direction === 'down' && target.nextElementSibling) {
+        target.parentElement.insertBefore(target.nextElementSibling, target);
+    }
+    emitVisualValue();
+}
+
+function blockLabel(type) {
+    const labels = {
+        title: 'Título', text: 'Texto', content: 'Seção', hero: 'Hero', columns: 'Duas colunas',
+        product: 'Produto', coupon: 'Cupom', benefits: 'Benefícios', testimonial: 'Depoimento',
+        social: 'Redes sociais', footer: 'Rodapé', divider: 'Divisor', spacer: 'Espaçamento',
+    };
+    return labels[type] || 'Bloco';
+}
+
+function updateTextColor(event) {
+    textColor.value = event.target.value;
+    run('foreColor', textColor.value);
+}
+
+function updateBackgroundColor(event) {
+    backgroundColor.value = event.target.value;
+    if (!editor.value) return;
+    recordHistory();
+
+    let wrapper = editor.value.querySelector(':scope > [data-email-background="true"]');
+    if (!wrapper) {
+        const currentHtml = editor.value.innerHTML || '<p><br></p>';
+        editor.value.innerHTML = `<div data-email-background="true" style="background-color:${backgroundColor.value};padding:24px;">${currentHtml}</div>`;
+        wrapper = editor.value.firstElementChild;
+    }
+    wrapper.style.backgroundColor = backgroundColor.value;
+    emitVisualValue();
+}
+
+function findExternalSurface() {
+    if (!editor.value) return null;
+    return editor.value.querySelector(':scope > [data-email-background="true"], :scope > table');
+}
+
+function updateContentBackgroundColor(event) {
+    contentBackgroundColor.value = event.target.value;
+    recordHistory();
+    const content = findContentSurface() || ensureEmailWrappers().content;
+    if (!content) return;
+    content.style.backgroundColor = contentBackgroundColor.value;
+    emitVisualValue();
+}
+
+function updateTypography() {
+    recordHistory();
+    const content = findContentSurface() || ensureEmailWrappers().content;
+    if (!content) return;
+
+    Object.assign(content.style, {
+        fontFamily: typographySettings.fontFamily,
+        fontSize: `${typographySettings.fontSize}px`,
+        lineHeight: String(typographySettings.lineHeight),
+        color: typographySettings.color,
+    });
+
+    content.querySelectorAll('p, li, td, span, blockquote, footer').forEach((element) => {
+        element.style.fontFamily = typographySettings.fontFamily;
+        element.style.fontSize = `${typographySettings.fontSize}px`;
+        element.style.lineHeight = String(typographySettings.lineHeight);
+        element.style.color = typographySettings.color;
+    });
+    content.querySelectorAll('h1, h2, h3, h4').forEach((element) => {
+        element.style.fontFamily = typographySettings.fontFamily;
+        element.style.lineHeight = String(typographySettings.lineHeight);
+        element.style.color = typographySettings.color;
+    });
+
+    emitVisualValue();
+}
+
+function findContentSurface() {
+    if (!editor.value) return null;
+
+    const explicitContent = editor.value.querySelector(':scope > [data-email-background="true"] > [data-email-content="true"]');
+    if (explicitContent) return explicitContent;
+
+    const rootTable = editor.value.querySelector(
+        ':scope > table, :scope > [data-email-background="true"] > table, :scope > [data-email-background="true"] > [data-email-content="true"] > table',
+    );
+    if (rootTable) {
+        return rootTable.querySelector(':scope > tbody > tr > td, :scope > tr > td');
+    }
+
+    return null;
+}
+
+function ensureEmailWrappers() {
+    if (!editor.value) return {};
+
+    let background = editor.value.querySelector(':scope > [data-email-background="true"]');
+    if (!background) {
+        const currentHtml = editor.value.innerHTML || '<p><br></p>';
+        editor.value.innerHTML = `<div data-email-background="true" style="background-color:${backgroundColor.value};padding:24px;"><div data-email-content="true" style="background-color:${contentBackgroundColor.value};padding:24px;">${currentHtml}</div></div>`;
+        background = editor.value.firstElementChild;
+    }
+
+    let content = background.querySelector(':scope > [data-email-content="true"]');
+    if (!content) {
+        const currentHtml = background.innerHTML || '<p><br></p>';
+        background.innerHTML = `<div data-email-content="true" style="background-color:${contentBackgroundColor.value};padding:24px;">${currentHtml}</div>`;
+        content = background.firstElementChild;
+    }
+
+    return { background, content };
+}
+
+function syncGeneralColors() {
+    if (!editor.value) return;
+    const background = findExternalSurface();
+    const content = findContentSurface();
+    backgroundColor.value = colorToHex(background?.style.backgroundColor, '#f8fafc');
+    contentBackgroundColor.value = colorToHex(content?.style.backgroundColor, '#ffffff');
+    typographySettings.fontFamily = content?.style.fontFamily || 'Arial, sans-serif';
+    typographySettings.fontSize = parseFloat(content?.style.fontSize) || 15;
+    typographySettings.lineHeight = parseFloat(content?.style.lineHeight) || 1.6;
+    typographySettings.color = colorToHex(content?.style.color, '#334155');
+}
+
+function insertPlaceholder(value = selectedPlaceholder.value) {
+    const placeholder = typeof value === 'string' ? value : selectedPlaceholder.value;
+    if (!placeholder || props.disabled) return;
+    if (!sourceMode.value) recordHistory();
+    if (sourceMode.value) {
+        emit('update:modelValue', `${props.modelValue || ''}${placeholder}`);
+    } else {
+        editor.value?.focus();
+        restoreSelection();
+
+        const selection = window.getSelection();
+        if (selection?.rangeCount) {
+            const range = selection.getRangeAt(0);
+            range.deleteContents();
+
+            const textNode = document.createTextNode(placeholder);
+            range.insertNode(textNode);
+            range.setStartAfter(textNode);
+            range.collapse(true);
+
+            selection.removeAllRanges();
+            selection.addRange(range);
+            savedRange.value = range.cloneRange();
+            emitVisualValue();
+        }
+    }
+    selectedPlaceholder.value = '';
+}
+
+async function toggleSourceMode() {
+    sourceMode.value = !sourceMode.value;
+    await nextTick();
+    if (!sourceMode.value) syncEditor();
+}
+
+watch(() => props.modelValue, syncEditor);
+onMounted(syncEditor);
+
+const toolButtonClass = 'inline-flex h-8 w-8 items-center justify-center rounded-md text-zinc-600 transition hover:bg-zinc-200 hover:text-zinc-900 disabled:cursor-not-allowed disabled:opacity-40 dark:text-zinc-300 dark:hover:bg-zinc-700 dark:hover:text-white';
+</script>
+
+<template>
+    <div class="overflow-hidden rounded-xl border border-zinc-300 bg-white dark:border-zinc-600 dark:bg-zinc-900" :class="{ 'opacity-60': disabled }">
+        <div class="flex flex-wrap items-center justify-between gap-3 border-b border-zinc-200 bg-white px-4 py-3 dark:border-zinc-700 dark:bg-zinc-900">
+            <div>
+                <p class="text-sm font-semibold text-zinc-900 dark:text-white">Editor de e-mail</p>
+                <p class="text-xs text-zinc-500">Selecione um bloco para editar suas propriedades.</p>
+            </div>
+            <div class="flex items-center gap-2">
+                <div class="flex rounded-lg border border-zinc-300 p-0.5 dark:border-zinc-600">
+                    <button type="button" class="rounded-md px-2.5 py-1.5 text-xs" :class="previewMode === 'desktop' ? 'bg-zinc-900 text-white dark:bg-white dark:text-zinc-900' : 'text-zinc-500'" @click="previewMode = 'desktop'">Desktop</button>
+                    <button type="button" class="rounded-md px-2.5 py-1.5 text-xs" :class="previewMode === 'mobile' ? 'bg-zinc-900 text-white dark:bg-white dark:text-zinc-900' : 'text-zinc-500'" @click="previewMode = 'mobile'">Mobile</button>
+                </div>
+                <select v-if="placeholders.length" v-model="selectedPlaceholder" class="h-9 rounded-lg border border-zinc-300 bg-white px-2 text-xs dark:border-zinc-600 dark:bg-zinc-800" :disabled="disabled" @change="insertPlaceholder($event.target.value)">
+                    <option value="">Inserir variável...</option>
+                    <option v-for="item in placeholders" :key="item.value || item" :value="item.value || item">{{ item.label || item.value || item }}</option>
+                </select>
+                <button v-if="placeholders.length" type="button" :class="toolButtonClass" :disabled="disabled || !selectedPlaceholder" title="Inserir variável" @click="insertPlaceholder()"><Pilcrow class="h-4 w-4" /></button>
+                <button type="button" class="inline-flex h-9 items-center gap-2 rounded-lg border border-zinc-300 px-3 text-xs font-medium dark:border-zinc-600" :class="{ 'bg-zinc-900 text-white dark:bg-white dark:text-zinc-900': sourceMode }" :disabled="disabled" @click="toggleSourceMode">
+                    <Code2 class="h-4 w-4" /> {{ sourceMode ? 'Visual' : 'HTML' }}
+                </button>
+            </div>
+        </div>
+
+        <div class="grid min-h-[520px] xl:grid-cols-[170px_minmax(360px,1fr)_270px]">
+            <aside class="border-b border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-700 dark:bg-zinc-800/60 xl:border-b-0 xl:border-r">
+                <p class="mb-2 text-xs font-semibold uppercase tracking-wide text-zinc-500">Blocos</p>
+                <div class="grid grid-cols-3 gap-2 sm:grid-cols-5 xl:grid-cols-2">
+                    <button v-for="block in blockLibrary" :key="block.type" type="button" class="rounded-lg border border-zinc-200 bg-white px-2 py-2.5 text-xs font-medium text-zinc-700 shadow-sm transition hover:border-[var(--color-primary)] hover:text-[var(--color-primary)] dark:border-zinc-600 dark:bg-zinc-900 dark:text-zinc-200" :disabled="disabled || sourceMode" @click="insertPreset(block.type)">
+                        {{ block.label }}
+                    </button>
+                </div>
+            </aside>
+
+            <main class="min-w-0 bg-zinc-100 dark:bg-zinc-950/50">
+                <div v-if="!sourceMode" class="flex flex-wrap items-center gap-1 border-b border-zinc-200 bg-white px-3 py-2 dark:border-zinc-700 dark:bg-zinc-900">
+                    <button type="button" :class="toolButtonClass" title="Desfazer" @click="undoEditor"><Undo2 class="h-4 w-4" /></button>
+                    <button type="button" :class="toolButtonClass" title="Refazer" @click="redoEditor"><Redo2 class="h-4 w-4" /></button>
+                    <select class="h-8 rounded-md border border-zinc-300 bg-white px-2 text-xs dark:border-zinc-600 dark:bg-zinc-800" @change="setBlock($event.target.value); $event.target.value = 'p'">
+                        <option value="p">Parágrafo</option><option value="h1">Título 1</option><option value="h2">Título 2</option><option value="h3">Título 3</option>
+                    </select>
+                    <button type="button" :class="toolButtonClass" title="Negrito" @click="run('bold')"><Bold class="h-4 w-4" /></button>
+                    <button type="button" :class="toolButtonClass" title="Itálico" @click="run('italic')"><Italic class="h-4 w-4" /></button>
+                    <button type="button" :class="toolButtonClass" title="Sublinhado" @click="run('underline')"><Underline class="h-4 w-4" /></button>
+                    <button type="button" :class="toolButtonClass" title="Lista" @click="run('insertUnorderedList')"><List class="h-4 w-4" /></button>
+                    <button type="button" :class="toolButtonClass" title="Lista numerada" @click="run('insertOrderedList')"><ListOrdered class="h-4 w-4" /></button>
+                    <button type="button" :class="toolButtonClass" title="Esquerda" @click="run('justifyLeft')"><AlignLeft class="h-4 w-4" /></button>
+                    <button type="button" :class="toolButtonClass" title="Centro" @click="run('justifyCenter')"><AlignCenter class="h-4 w-4" /></button>
+                    <button type="button" :class="toolButtonClass" title="Direita" @click="run('justifyRight')"><AlignRight class="h-4 w-4" /></button>
+                    <button type="button" :class="toolButtonClass" title="Adicionar link" @click="createLink"><Link class="h-4 w-4" /></button>
+                    <label class="flex h-8 items-center gap-1 rounded-md border border-zinc-300 px-2 text-[11px] dark:border-zinc-600">Texto <input v-model="textColor" type="color" class="h-5 w-5 border-0 bg-transparent p-0" @input="updateTextColor" /></label>
+                    <button type="button" :class="toolButtonClass" title="Limpar formatação" @click="run('removeFormat')"><RemoveFormatting class="h-4 w-4" /></button>
+                </div>
+                <div class="p-4 sm:p-6">
+                    <textarea v-if="sourceMode" :value="modelValue" :disabled="disabled" :required="required" class="mx-auto block w-full max-w-[700px] resize-y rounded-lg border border-zinc-300 bg-zinc-950 px-4 py-3 font-mono text-sm text-zinc-100 outline-none" :style="{ minHeight }" aria-label="Código HTML do e-mail" @input="emit('update:modelValue', $event.target.value)" />
+                    <div v-else ref="editor" class="email-visual-editor mx-auto block w-full overflow-auto rounded-sm bg-white px-7 py-6 text-sm text-zinc-900 shadow-md outline-none transition-[max-width]" :class="[previewMode === 'mobile' ? 'max-w-[375px]' : 'max-w-[600px]', { 'cursor-not-allowed': disabled }]" :contenteditable="disabled ? 'false' : 'true'" :style="{ minHeight }" role="textbox" aria-multiline="true" aria-label="Editor visual do e-mail" @click="selectEditableElement" @focus="rememberSelection" @keyup="rememberSelection" @mouseup="rememberSelection" @input="rememberSelection(); emitVisualValue()" @blur="emitVisualValue" />
+                </div>
+            </main>
+
+            <aside class="border-t border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900 xl:border-l xl:border-t-0">
+                <template v-if="selectedType === 'button'">
+                    <p class="mb-3 text-sm font-semibold">Botão</p>
+                    <div class="space-y-3">
+                        <label class="block text-xs font-medium">Texto<input v-model="buttonSettings.text" class="mt-1 block w-full rounded-md border border-zinc-300 px-2.5 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800" @input="updateSelectedButton" /></label>
+                        <label class="block text-xs font-medium">URL<input v-model="buttonSettings.url" type="url" placeholder="https://..." class="mt-1 block w-full rounded-md border border-zinc-300 px-2.5 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800" @input="updateSelectedButton" /></label>
+                        <label class="flex items-center justify-between text-xs font-medium">Cor do botão<input v-model="buttonSettings.backgroundColor" type="color" class="h-8 w-10" @input="updateSelectedButton" /></label>
+                        <label class="flex items-center justify-between text-xs font-medium">Cor do texto<input v-model="buttonSettings.textColor" type="color" class="h-8 w-10" @input="updateSelectedButton" /></label>
+                        <label class="block text-xs font-medium">Alinhamento<select v-model="buttonSettings.alignment" class="mt-1 block w-full rounded-md border border-zinc-300 px-2 py-2 dark:border-zinc-600 dark:bg-zinc-800" @change="updateSelectedButton"><option value="left">Esquerda</option><option value="center">Centro</option><option value="right">Direita</option></select></label>
+                        <label class="block text-xs font-medium">Bordas: {{ buttonSettings.borderRadius }}px<input v-model.number="buttonSettings.borderRadius" type="range" min="0" max="32" class="mt-1 block w-full" @input="updateSelectedButton" /></label>
+                        <label class="flex items-center gap-2 text-xs"><input v-model="buttonSettings.fullWidth" type="checkbox" @change="updateSelectedButton" /> Largura inteira</label>
+                    </div>
+                </template>
+                <template v-else-if="selectedType === 'image'">
+                    <p class="mb-3 text-sm font-semibold">Imagem</p>
+                    <div class="space-y-3">
+                        <label class="block text-xs font-medium">URL pública<input v-model="imageSettings.url" type="url" placeholder="https://.../imagem.jpg" class="mt-1 block w-full rounded-md border border-zinc-300 px-2.5 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800" @input="updateSelectedImage" /></label>
+                        <label class="block text-xs font-medium">Texto alternativo<input v-model="imageSettings.alt" class="mt-1 block w-full rounded-md border border-zinc-300 px-2.5 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800" @input="updateSelectedImage" /></label>
+                        <label class="block text-xs font-medium">Link ao clicar<input v-model="imageSettings.link" type="url" placeholder="https://..." class="mt-1 block w-full rounded-md border border-zinc-300 px-2.5 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800" @input="updateSelectedImage" /></label>
+                        <label class="block text-xs font-medium">Largura: {{ imageSettings.width }}px<input v-model.number="imageSettings.width" type="range" min="100" max="800" step="10" class="mt-1 block w-full" @input="updateSelectedImage" /></label>
+                        <label class="block text-xs font-medium">Bordas: {{ imageSettings.borderRadius }}px<input v-model.number="imageSettings.borderRadius" type="range" min="0" max="40" class="mt-1 block w-full" @input="updateSelectedImage" /></label>
+                    </div>
+                </template>
+                <template v-else-if="selectedType === 'link'">
+                    <p class="mb-3 text-sm font-semibold">Link</p>
+                    <div class="space-y-3">
+                        <label class="block text-xs font-medium">Texto<input v-model="linkSettings.text" class="mt-1 block w-full rounded-md border border-zinc-300 px-2.5 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800" @input="updateSelectedLink" /></label>
+                        <label class="block text-xs font-medium">URL<input v-model="linkSettings.url" type="url" placeholder="https://..." class="mt-1 block w-full rounded-md border border-zinc-300 px-2.5 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800" @input="updateSelectedLink" /></label>
+                        <label class="flex items-center justify-between text-xs font-medium">Cor<input v-model="linkSettings.color" type="color" class="h-8 w-10" @input="updateSelectedLink" /></label>
+                    </div>
+                </template>
+                <template v-else-if="selectedType === 'block'">
+                    <p class="text-sm font-semibold">{{ blockLabel(selectedElement?.dataset?.emailBlockType) }}</p>
+                    <p class="mt-1 text-xs text-zinc-500">Edite o texto diretamente no canvas ou use as ações abaixo.</p>
+                </template>
+                <template v-else>
+                    <p class="mb-3 text-sm font-semibold">Estilo geral</p>
+                    <div class="space-y-3">
+                        <label class="flex items-center justify-between text-xs font-medium">Fundo sem conteúdo<input v-model="backgroundColor" type="color" class="h-8 w-10" @input="updateBackgroundColor" /></label>
+                        <label class="flex items-center justify-between text-xs font-medium">Fundo com conteúdo<input v-model="contentBackgroundColor" type="color" class="h-8 w-10" @input="updateContentBackgroundColor" /></label>
+                        <label class="block text-xs font-medium">Fonte<select v-model="typographySettings.fontFamily" class="mt-1 block w-full rounded-md border border-zinc-300 px-2 py-2 dark:border-zinc-600 dark:bg-zinc-800" @change="updateTypography"><option value="Arial, sans-serif">Arial</option><option value="'Segoe UI', Arial, sans-serif">Segoe UI</option><option value="Georgia, serif">Georgia</option><option value="Tahoma, sans-serif">Tahoma</option><option value="Verdana, sans-serif">Verdana</option></select></label>
+                        <label class="block text-xs font-medium">Tamanho do texto: {{ typographySettings.fontSize }}px<input v-model.number="typographySettings.fontSize" type="range" min="10" max="24" class="mt-1 block w-full" @input="updateTypography" /></label>
+                        <label class="block text-xs font-medium">Altura da linha: {{ typographySettings.lineHeight }}<input v-model.number="typographySettings.lineHeight" type="range" min="1" max="2.2" step="0.1" class="mt-1 block w-full" @input="updateTypography" /></label>
+                        <label class="flex items-center justify-between text-xs font-medium">Cor geral do texto<input v-model="typographySettings.color" type="color" class="h-8 w-10" @input="updateTypography" /></label>
+                    </div>
+                    <p class="mt-4 rounded-lg bg-zinc-50 p-3 text-xs leading-relaxed text-zinc-500 dark:bg-zinc-800">Adicione blocos pela biblioteca e clique em qualquer botão, imagem ou link para abrir suas propriedades.</p>
+                </template>
+
+                <div v-if="selectedType" class="mt-5 border-t border-zinc-200 pt-4 dark:border-zinc-700">
+                    <p class="mb-2 text-xs font-semibold uppercase tracking-wide text-zinc-500">Ações</p>
+                    <div class="grid grid-cols-2 gap-2">
+                        <button type="button" class="rounded-md border border-zinc-300 px-2 py-2 text-xs dark:border-zinc-600" @click="moveSelectedElement('up')">Mover acima</button>
+                        <button type="button" class="rounded-md border border-zinc-300 px-2 py-2 text-xs dark:border-zinc-600" @click="moveSelectedElement('down')">Mover abaixo</button>
+                        <button type="button" class="rounded-md border border-zinc-300 px-2 py-2 text-xs dark:border-zinc-600" @click="duplicateSelectedElement">Duplicar</button>
+                        <button type="button" class="rounded-md border border-red-200 px-2 py-2 text-xs text-red-600 dark:border-red-800" @click="removeSelectedElement">Excluir</button>
+                    </div>
+                </div>
+            </aside>
+        </div>
+    </div>
+</template>
+
+<style scoped>
+.email-visual-editor :deep(a) { color: #0284c7; text-decoration: underline; }
+.email-visual-editor :deep(ul) { list-style: disc; padding-left: 1.5rem; }
+.email-visual-editor :deep(ol) { list-style: decimal; padding-left: 1.5rem; }
+.email-visual-editor :deep(h1) { font-size: 2em; font-weight: 700; line-height: 1.2; }
+.email-visual-editor :deep(h2) { font-size: 1.5em; font-weight: 700; line-height: 1.25; }
+.email-visual-editor :deep(h3) { font-size: 1.17em; font-weight: 700; line-height: 1.3; }
+.email-visual-editor :deep([data-email-block="true"]) { transition: outline-color 0.15s ease; outline: 2px solid transparent; outline-offset: 3px; }
+.email-visual-editor :deep([data-email-block="true"]:hover) { outline-color: #38bdf8; }
+.email-visual-editor :deep([data-email-button="true"]),
+.email-visual-editor :deep([data-email-image-block="true"]),
+.email-visual-editor :deep([data-email-link="true"]) { cursor: pointer; }
+</style>

--- a/tests/Feature/ProductEmailVisualEditorTest.php
+++ b/tests/Feature/ProductEmailVisualEditorTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Middleware\EnsureInstalled;
+use App\Models\Product;
+use App\Models\User;
+use Tests\TestCase;
+
+class ProductEmailVisualEditorTest extends TestCase
+{
+    public function test_product_update_persists_visual_email_html(): void
+    {
+        $this->withoutMiddleware(EnsureInstalled::class);
+
+        $user = User::factory()->create([
+            'role' => User::ROLE_INFOPRODUTOR,
+            'tenant_id' => 1,
+        ]);
+
+        $product = $this->createTestProduct([
+            'name' => 'Produto com editor visual',
+            'slug' => 'produto-editor-visual',
+        ]);
+
+        $accessHtml = '<h1>Olá {nome_cliente}</h1><p><strong>{nome_produto}</strong></p>';
+        $recoveryHtml = '<p>Retome por <a href="{link_checkout}">este link</a>.</p>';
+
+        $response = $this->actingAs($user)->put("/produtos/{$product->id}", [
+            'name' => $product->name,
+            'slug' => $product->slug,
+            'description' => '',
+            'type' => Product::TYPE_LINK,
+            'billing_type' => Product::BILLING_ONE_TIME,
+            'price' => 49.9,
+            'currency' => 'BRL',
+            'is_active' => true,
+            'email_template' => [
+                'subject' => 'Seu acesso a {nome_produto}',
+                'body_text' => '',
+                'body_html' => $accessHtml,
+            ],
+            'cart_recovery_email' => [
+                'enabled' => true,
+                'stages' => [
+                    '10m' => [
+                        'subject' => 'Finalize sua compra',
+                        'body_text' => '',
+                        'body_html' => $recoveryHtml,
+                    ],
+                ],
+            ],
+        ]);
+
+        $response->assertRedirect();
+
+        $config = $product->fresh()->checkout_config;
+        $this->assertSame($accessHtml, $config['email_template']['body_html']);
+        $this->assertEmpty($config['email_template']['body_text']);
+        $this->assertSame($recoveryHtml, $config['cart_recovery_email']['stages']['10m']['body_html']);
+        $this->assertEmpty($config['cart_recovery_email']['stages']['10m']['body_text']);
+    }
+}


### PR DESCRIPTION
## O que foi implementado

- Adiciona um editor visual reutilizável para templates de e-mail;
- Integra o editor às campanhas de e-mail marketing;
- Separa os templates de acesso e recuperação em abas;
- Adiciona blocos pré-construídos para composição dos e-mails;
- Permite editar botões, links e imagens por URL;
- Adiciona cores independentes para o fundo externo e para o conteúdo;
- Adiciona configurações gerais de fonte, tamanho, cor e altura da linha;
- permite a inserção de variáveis, pré definidas.
- Adiciona histórico próprio para desfazer e refazer alterações;
- Prioriza o HTML personalizado nos envios de acesso e recuperação, mantendo compatibilidade com texto simples.

## Melhorias nos e-mails de recuperação padrões

- aprimora os layouts padrão das etapas de 10 minutos, 5 horas e 24 horas;
- adiciona melhor hierarquia visual, resumo do produto e valor;
- melhora os textos, CTAs, links alternativos e mensagens de suporte;
- adiciona o botão **Usar layout padrão** em cada etapa;
- exibe confirmação antes de substituir o assunto e o conteúdo atual;
- preserva templates personalizados até que a restauração seja confirmada.

<img width="913" height="629" alt="image" src="https://github.com/user-attachments/assets/f82c38e5-56f6-40a5-93a4-4e23746a5fda" />


## Motivação

A issue solicita uma forma mais visual e amigável de personalizar os e-mails. Antes, a edição dependia principalmente de conteúdo textual ou HTML manual e não oferecia uma experiência consistente entre campanhas, acesso ao produto e recuperação de carrinho.

## Impacto

Os produtores podem criar e visualizar templates profissionais sem editar HTML manualmente. Os templates existentes continuam compatíveis, e a versão em texto permanece disponível como alternativa.

## Validação

- Build de produção do Vite concluído com sucesso;
- Teste `ProductEmailVisualEditorTest` aprovado;
- 1 teste e 5 asserções aprovadas;
- Fluxos de acesso e recuperação validados no ambiente local.

Closes #30