### PR TITLE
feat: adiciona duração de acesso ao conteúdo - Módulo e Aula

### DIFF
--- a/app/Http/Controllers/MemberAreaAppController.php
+++ b/app/Http/Controllers/MemberAreaAppController.php
@@ -302,6 +302,7 @@ class MemberAreaAppController extends Controller
                 'title' => $module->title,
                 'thumbnail' => $this->moduleThumbnailUrl($module, $product, $effectiveModule),
                 'section' => $module->section ? ['id' => $module->section->id, 'title' => $module->section->title] : null,
+                ...$moduleLock,
             ],
             'lessons' => $lessons,
             'current_lesson' => $currentLessonData,
@@ -448,7 +449,7 @@ class MemberAreaAppController extends Controller
      */
     public function presentationPdf(Request $request, string $slug, MemberLesson $lesson, int $fileIndex): SymfonyResponse
     {
-        $this->assertLessonViewableForPdf($request, $lesson);
+        $this->assertLessonViewable($request, $lesson);
         if (! in_array($lesson->type, [MemberLesson::TYPE_PDF_PRESENTATION, MemberLesson::TYPE_PDF_READER], true)) {
             abort(404);
         }
@@ -481,7 +482,7 @@ class MemberAreaAppController extends Controller
         if (! $user) {
             return response()->json(['message' => 'Não autenticado.'], 401);
         }
-        $this->assertLessonViewableForPdf($request, $lesson);
+        $this->assertLessonViewable($request, $lesson);
         if ($lesson->type !== MemberLesson::TYPE_PDF_READER) {
             abort(404);
         }
@@ -510,7 +511,7 @@ class MemberAreaAppController extends Controller
         if (! $user) {
             return response()->json(['message' => 'Não autenticado.'], 401);
         }
-        $this->assertLessonViewableForPdf($request, $lesson);
+        $this->assertLessonViewable($request, $lesson);
         if ($lesson->type !== MemberLesson::TYPE_PDF_READER) {
             abort(404);
         }
@@ -550,7 +551,7 @@ class MemberAreaAppController extends Controller
         if (! $user) {
             return response()->json(['message' => 'Não autenticado.'], 401);
         }
-        $this->assertLessonViewableForPdf($request, $lesson);
+        $this->assertLessonViewable($request, $lesson);
 
         $liked = false;
         $count = (int) ($lesson->likes_count ?? 0);
@@ -591,7 +592,7 @@ class MemberAreaAppController extends Controller
         if (! $user) {
             return response()->json(['message' => 'Não autenticado.'], 401);
         }
-        $this->assertLessonViewableForPdf($request, $lesson);
+        $this->assertLessonViewable($request, $lesson);
 
         $validated = $request->validate([
             'notes' => ['nullable', 'string', 'max:5000'],
@@ -838,6 +839,7 @@ class MemberAreaAppController extends Controller
                 return $redirect;
             }
         }
+        $this->assertLessonViewable($request, $lesson);
         $this->progressService->markLessonCompleted($lesson->id, $user);
 
         $this->logMemberActivity($request, $product, $user, 'member_area.lesson_complete', [
@@ -873,6 +875,7 @@ class MemberAreaAppController extends Controller
                 return $redirect;
             }
         }
+        $this->assertLessonViewable($request, $lesson);
         $config = $product->member_area_config;
         if (empty($config['comments_enabled'])) {
             abort(403, 'Comentários desativados para este produto.');
@@ -1782,13 +1785,35 @@ class MemberAreaAppController extends Controller
         return ['available_at' => null, 'mode' => null];
     }
 
-    private function lockPayload(?Carbon $availableAt, Carbon $now, ?string $mode): array
+    private function accessExpiresAt(?int $durationDays, Carbon $accessStartAt): ?Carbon
     {
-        if (! $availableAt) {
-            return ['is_locked' => false, 'available_at' => null, 'lock_message' => null];
+        if (! is_int($durationDays) || $durationDays <= 0 || auth()->user()?->canAccessPanel()) {
+            return null;
         }
-        if ($availableAt->lessThanOrEqualTo($now)) {
-            return ['is_locked' => false, 'available_at' => $availableAt->toIso8601String(), 'lock_message' => null];
+
+        return $accessStartAt->copy()->addDays($durationDays);
+    }
+
+    private function lockPayload(?Carbon $availableAt, ?Carbon $expiresAt, Carbon $now, ?string $mode): array
+    {
+        $payload = [
+            'is_locked' => false,
+            'available_at' => $availableAt?->toIso8601String(),
+            'expires_at' => $expiresAt?->toIso8601String(),
+            'lock_message' => null,
+            'lock_reason' => null,
+        ];
+
+        if ($expiresAt && $expiresAt->lessThanOrEqualTo($now)) {
+            return [
+                ...$payload,
+                'is_locked' => true,
+                'lock_message' => 'Acesso encerrado em '.$expiresAt->format('d/m/Y'),
+                'lock_reason' => 'expired',
+            ];
+        }
+        if (! $availableAt || $availableAt->lessThanOrEqualTo($now)) {
+            return $payload;
         }
         $message = null;
         if ($mode === 'date') {
@@ -1802,13 +1827,20 @@ class MemberAreaAppController extends Controller
         } else {
             $message = 'Disponível em '.$availableAt->format('d/m/Y H:i');
         }
-        return ['is_locked' => true, 'available_at' => $availableAt->toIso8601String(), 'lock_message' => $message];
+        return [
+            ...$payload,
+            'is_locked' => true,
+            'lock_message' => $message,
+            'lock_reason' => 'scheduled',
+        ];
     }
 
     private function moduleLockPayload(MemberModule $module, Carbon $accessStartAt, Carbon $now): array
     {
         $meta = $this->scheduleMeta($module->release_after_days, $module->release_at_date, $accessStartAt);
-        return $this->lockPayload($meta['available_at'], $now, $meta['mode']);
+        $expiresAt = $this->accessExpiresAt($module->access_duration_days, $accessStartAt);
+
+        return $this->lockPayload($meta['available_at'], $expiresAt, $now, $meta['mode']);
     }
 
     private function lessonLockPayload(MemberLesson $lesson, ?MemberModule $module, Carbon $accessStartAt, Carbon $now): array
@@ -1837,7 +1869,16 @@ class MemberAreaAppController extends Controller
                 $mode = $moduleMeta['mode'];
             }
         }
-        return $this->lockPayload($availableAt, $now, $mode);
+        $lessonExpiresAt = $this->accessExpiresAt($lesson->access_duration_days, $accessStartAt);
+        $moduleExpiresAt = $module ? $this->accessExpiresAt($module->access_duration_days, $accessStartAt) : null;
+        $expiresAt = null;
+        if ($lessonExpiresAt && $moduleExpiresAt) {
+            $expiresAt = $lessonExpiresAt->lessThanOrEqualTo($moduleExpiresAt) ? $lessonExpiresAt : $moduleExpiresAt;
+        } else {
+            $expiresAt = $lessonExpiresAt ?? $moduleExpiresAt;
+        }
+
+        return $this->lockPayload($availableAt, $expiresAt, $now, $mode);
     }
 
     private function moduleThumbnailUrl(MemberModule $module, Product $product, ?MemberModule $fallback = null): ?string
@@ -2098,7 +2139,7 @@ class MemberAreaAppController extends Controller
         return $this->resolver->baseUrlForProduct($product);
     }
 
-    private function assertLessonViewableForPdf(Request $request, MemberLesson $lesson): void
+    private function assertLessonViewable(Request $request, MemberLesson $lesson): void
     {
         $product = $this->getProduct($request);
         $user = $request->user();

--- a/app/Http/Controllers/MemberBuilderController.php
+++ b/app/Http/Controllers/MemberBuilderController.php
@@ -212,6 +212,7 @@ class MemberBuilderController extends Controller
                         'show_title_on_cover' => $m->show_title_on_cover ?? true,
                         'release_after_days' => $m->release_after_days,
                         'release_at_date' => $m->release_at_date?->format('Y-m-d'),
+                        'access_duration_days' => $m->access_duration_days,
                         'lessons' => $m->lessons->map(fn (MemberLesson $l) => [
                             'id' => $l->id,
                             'title' => $l->title,
@@ -224,6 +225,7 @@ class MemberBuilderController extends Controller
                             'useful_links' => $l->useful_links,
                             'release_after_days' => $l->release_after_days,
                             'release_at_date' => $l->release_at_date?->format('Y-m-d'),
+                            'access_duration_days' => $l->access_duration_days,
                             'content_text' => \App\Support\HtmlSanitizer::sanitize($l->content_text),
                             'duration_seconds' => $l->duration_seconds,
                             'is_free' => $l->is_free,
@@ -782,6 +784,7 @@ class MemberBuilderController extends Controller
                 'show_title_on_cover' => ['nullable', 'boolean'],
                 'release_after_days' => ['nullable', 'integer', 'min:1', 'max:3650'],
                 'release_at_date' => ['nullable', 'date_format:Y-m-d'],
+                'access_duration_days' => ['nullable', 'integer', 'min:1', 'max:3650'],
             ]);
             if (! empty($validated['release_at_date'] ?? null)) {
                 $validated['release_after_days'] = null;
@@ -800,6 +803,7 @@ class MemberBuilderController extends Controller
                 'show_title_on_cover' => $validated['show_title_on_cover'] ?? true,
                 'release_after_days' => $validated['release_after_days'] ?? null,
                 'release_at_date' => $validated['release_at_date'] ?? null,
+                'access_duration_days' => $validated['access_duration_days'] ?? null,
             ]);
         } elseif ($sectionType === 'products') {
             $validated = $request->validate([
@@ -929,12 +933,16 @@ class MemberBuilderController extends Controller
             'show_title_on_cover' => $module->show_title_on_cover ?? true,
             'release_after_days' => $module->release_after_days,
             'release_at_date' => $module->release_at_date?->format('Y-m-d'),
+            'access_duration_days' => $module->access_duration_days,
             'lessons' => $module->relationLoaded('lessons') ? $module->lessons->map(fn (MemberLesson $l) => [
                 'id' => $l->id,
                 'title' => $l->title,
                 'position' => $l->position,
                 'type' => $l->type,
                 'content_url' => $l->content_url,
+                'release_after_days' => $l->release_after_days,
+                'release_at_date' => $l->release_at_date?->format('Y-m-d'),
+                'access_duration_days' => $l->access_duration_days,
                 'content_text' => \App\Support\HtmlSanitizer::sanitize($l->content_text),
                 'duration_seconds' => $l->duration_seconds,
                 'is_free' => $l->is_free,
@@ -976,6 +984,7 @@ class MemberBuilderController extends Controller
                 'show_title_on_cover' => ['sometimes', 'boolean'],
                 'release_after_days' => ['nullable', 'integer', 'min:1', 'max:3650'],
                 'release_at_date' => ['nullable', 'date_format:Y-m-d'],
+                'access_duration_days' => ['nullable', 'integer', 'min:1', 'max:3650'],
             ]);
             if (array_key_exists('release_at_date', $validated) || array_key_exists('release_after_days', $validated)) {
                 $date = $validated['release_at_date'] ?? null;
@@ -1101,6 +1110,7 @@ class MemberBuilderController extends Controller
             'useful_links.*.url' => ['nullable', 'string', 'max:2000', new StorageOrHttpUrl()],
             'release_after_days' => ['nullable', 'integer', 'min:1', 'max:3650'],
             'release_at_date' => ['nullable', 'date_format:Y-m-d'],
+            'access_duration_days' => ['nullable', 'integer', 'min:1', 'max:3650'],
             'content_text' => ['nullable', 'string'],
             'duration_seconds' => ['nullable', 'integer', 'min:0'],
             'is_free' => ['boolean'],
@@ -1137,6 +1147,7 @@ class MemberBuilderController extends Controller
             'useful_links' => $usefulLinks !== [] ? $usefulLinks : null,
             'release_after_days' => $validated['release_after_days'] ?? null,
             'release_at_date' => $validated['release_at_date'] ?? null,
+            'access_duration_days' => $validated['access_duration_days'] ?? null,
             'content_text' => $validated['content_text'] ?? null,
             'duration_seconds' => $validated['duration_seconds'] ?? null,
             'is_free' => $request->boolean('is_free', false),
@@ -1183,6 +1194,7 @@ class MemberBuilderController extends Controller
             'useful_links.*.url' => ['nullable', 'string', 'max:2000', new StorageOrHttpUrl()],
             'release_after_days' => ['nullable', 'integer', 'min:1', 'max:3650'],
             'release_at_date' => ['nullable', 'date_format:Y-m-d'],
+            'access_duration_days' => ['nullable', 'integer', 'min:1', 'max:3650'],
             'content_text' => ['nullable', 'string'],
             'duration_seconds' => ['nullable', 'integer', 'min:0'],
             'is_free' => ['boolean'],
@@ -1839,6 +1851,7 @@ class MemberBuilderController extends Controller
             'external_url' => $source->external_url,
             'release_after_days' => $source->release_after_days,
             'release_at_date' => $source->release_at_date,
+            'access_duration_days' => $source->access_duration_days,
         ]);
 
         $shouldCopyLessons = $copyLessons
@@ -1878,6 +1891,7 @@ class MemberBuilderController extends Controller
             'useful_links' => $source->useful_links,
             'release_after_days' => $source->release_after_days,
             'release_at_date' => $source->release_at_date,
+            'access_duration_days' => $source->access_duration_days,
             'content_text' => $source->content_text,
             'duration_seconds' => $source->duration_seconds,
             'is_free' => (bool) $source->is_free,
@@ -1902,6 +1916,7 @@ class MemberBuilderController extends Controller
             'useful_links' => $lesson->useful_links,
             'release_after_days' => $lesson->release_after_days,
             'release_at_date' => $lesson->release_at_date?->format('Y-m-d'),
+            'access_duration_days' => $lesson->access_duration_days,
             'content_text' => \App\Support\HtmlSanitizer::sanitize($lesson->content_text),
             'duration_seconds' => $lesson->duration_seconds,
             'is_free' => (bool) $lesson->is_free,
@@ -1924,6 +1939,7 @@ class MemberBuilderController extends Controller
             'show_title_on_cover' => $module->show_title_on_cover ?? true,
             'release_after_days' => $module->release_after_days,
             'release_at_date' => $module->release_at_date?->format('Y-m-d'),
+            'access_duration_days' => $module->access_duration_days,
             'lessons' => $module->lessons->map(fn (MemberLesson $l) => $this->serializeMemberLessonForBuilder($l))->values()->all(),
         ];
 

--- a/app/Models/MemberLesson.php
+++ b/app/Models/MemberLesson.php
@@ -31,6 +31,7 @@ class MemberLesson extends Model
         'useful_links',
         'release_after_days',
         'release_at_date',
+        'access_duration_days',
         'content_text',
         'duration_seconds',
         'is_free',
@@ -50,6 +51,7 @@ class MemberLesson extends Model
             'useful_links' => 'array',
             'release_after_days' => 'integer',
             'release_at_date' => 'date:Y-m-d',
+            'access_duration_days' => 'integer',
         ];
     }
 

--- a/app/Models/MemberModule.php
+++ b/app/Models/MemberModule.php
@@ -21,6 +21,7 @@ class MemberModule extends Model
         'external_url',
         'release_after_days',
         'release_at_date',
+        'access_duration_days',
     ];
 
     protected function casts(): array
@@ -30,6 +31,7 @@ class MemberModule extends Model
             'show_title_on_cover' => 'boolean',
             'release_after_days' => 'integer',
             'release_at_date' => 'date:Y-m-d',
+            'access_duration_days' => 'integer',
         ];
     }
 

--- a/database/migrations/2026_07_27_000001_add_access_duration_to_member_content.php
+++ b/database/migrations/2026_07_27_000001_add_access_duration_to_member_content.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('member_modules', function (Blueprint $table) {
+            if (! Schema::hasColumn('member_modules', 'access_duration_days')) {
+                $table->unsignedInteger('access_duration_days')->nullable()->after('release_at_date');
+            }
+        });
+
+        Schema::table('member_lessons', function (Blueprint $table) {
+            if (! Schema::hasColumn('member_lessons', 'access_duration_days')) {
+                $column = $table->unsignedInteger('access_duration_days')->nullable();
+                if (Schema::hasColumn('member_lessons', 'release_at_date')) {
+                    $column->after('release_at_date');
+                }
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('member_modules', function (Blueprint $table) {
+            if (Schema::hasColumn('member_modules', 'access_duration_days')) {
+                $table->dropColumn('access_duration_days');
+            }
+        });
+
+        Schema::table('member_lessons', function (Blueprint $table) {
+            if (Schema::hasColumn('member_lessons', 'access_duration_days')) {
+                $table->dropColumn('access_duration_days');
+            }
+        });
+    }
+};

--- a/resources/js/Pages/Produtos/MemberBuilder/Standalone.vue
+++ b/resources/js/Pages/Produtos/MemberBuilder/Standalone.vue
@@ -679,6 +679,7 @@ function openModulosLessonForm(lesson) {
             release_mode: lesson.release_at_date ? 'date' : (lesson.release_after_days ? 'days' : 'none'),
             release_after_days: lesson.release_after_days ? String(lesson.release_after_days) : '',
             release_at_date: lesson.release_at_date || '',
+            access_duration_days: lesson.access_duration_days ? String(lesson.access_duration_days) : '',
         };
     } else {
         modulosLessonForm.value = {
@@ -694,6 +695,7 @@ function openModulosLessonForm(lesson) {
             release_mode: 'none',
             release_after_days: '',
             release_at_date: '',
+            access_duration_days: '',
         };
     }
 }
@@ -822,6 +824,7 @@ function lessonPayload(form) {
     const firstFileUrl = contentFiles[0]?.url ?? '';
     let release_after_days = null;
     let release_at_date = null;
+    const accessDurationDays = parseInt(form.access_duration_days, 10);
     if (form.release_mode === 'days') {
         const days = parseInt(form.release_after_days, 10);
         release_after_days = Number.isFinite(days) && days > 0 ? days : null;
@@ -838,6 +841,7 @@ function lessonPayload(form) {
         useful_links: usefulLinks,
         release_after_days,
         release_at_date,
+        access_duration_days: Number.isFinite(accessDurationDays) && accessDurationDays > 0 ? accessDurationDays : null,
         content_text: form.content_text ?? '',
         duration_seconds: 0,
         is_free: false,
@@ -919,6 +923,7 @@ const editingModuleExternalUrl = ref('');
 const editingModuleReleaseMode = ref('none'); // none | days | date
 const editingModuleReleaseAfterDays = ref('');
 const editingModuleReleaseAtDate = ref('');
+const editingModuleAccessDurationDays = ref('');
 
 const sectionModalOpen = ref(false);
 const sectionModalTitle = ref('');
@@ -942,6 +947,7 @@ const moduleModalExternalUrl = ref('');
 const moduleModalReleaseMode = ref('none'); // none | days | date
 const moduleModalReleaseAfterDays = ref('');
 const moduleModalReleaseAtDate = ref('');
+const moduleModalAccessDurationDays = ref('');
 
 function openSectionEdit(section) {
     editingSectionTitle.value = section.title;
@@ -981,6 +987,7 @@ function openModuleEdit(mod) {
         editingModuleReleaseAfterDays.value = '';
         editingModuleReleaseAtDate.value = '';
     }
+    editingModuleAccessDurationDays.value = mod.access_duration_days ? String(mod.access_duration_days) : '';
     startEditModule(mod.id);
 }
 
@@ -992,6 +999,8 @@ async function saveModuleTitle() {
     const payload = { title: editingModuleTitle.value };
     if (sectionType === 'courses') {
         payload.show_title_on_cover = editingModuleShowTitleOnCover.value;
+        const accessDurationDays = parseInt(editingModuleAccessDurationDays.value, 10);
+        payload.access_duration_days = Number.isFinite(accessDurationDays) && accessDurationDays > 0 ? accessDurationDays : null;
         if (editingModuleReleaseMode.value === 'days') {
             const days = parseInt(editingModuleReleaseAfterDays.value, 10);
             payload.release_after_days = Number.isFinite(days) && days > 0 ? days : null;
@@ -1517,6 +1526,7 @@ function openModuleModal(sectionId) {
     moduleModalReleaseMode.value = 'none';
     moduleModalReleaseAfterDays.value = '';
     moduleModalReleaseAtDate.value = '';
+    moduleModalAccessDurationDays.value = '';
     clearModuleModalFile();
     moduleModalOpen.value = true;
 }
@@ -1555,6 +1565,8 @@ async function confirmNewModule() {
         let payload = { title };
         if (sectionType === 'courses') {
             payload.show_title_on_cover = moduleModalShowTitleOnCover.value;
+            const accessDurationDays = parseInt(moduleModalAccessDurationDays.value, 10);
+            payload.access_duration_days = Number.isFinite(accessDurationDays) && accessDurationDays > 0 ? accessDurationDays : null;
             if (moduleModalReleaseMode.value === 'days') {
                 const days = parseInt(moduleModalReleaseAfterDays.value, 10);
                 payload.release_after_days = Number.isFinite(days) && days > 0 ? days : null;
@@ -2409,6 +2421,7 @@ const inputClass = 'block w-full rounded-lg border border-zinc-300 bg-white px-3
                             :editing-module-release-mode="editingModuleReleaseMode"
                             :editing-module-release-after-days="editingModuleReleaseAfterDays"
                             :editing-module-release-at-date="editingModuleReleaseAtDate"
+                            :editing-module-access-duration-days="editingModuleAccessDurationDays"
                             :editing-module-thumbnail="editingModule?.thumbnail"
                             :module-thumbnail-uploading="moduleThumbnailUploading"
                             @open-section-modal="openSectionModal"
@@ -2451,6 +2464,7 @@ const inputClass = 'block w-full rounded-lg border border-zinc-300 bg-white px-3
                             @update:editing-module-release-mode="editingModuleReleaseMode = $event"
                             @update:editing-module-release-after-days="editingModuleReleaseAfterDays = $event"
                             @update:editing-module-release-at-date="editingModuleReleaseAtDate = $event"
+                            @update:editing-module-access-duration-days="editingModuleAccessDurationDays = $event"
                         />
                     </template>
 
@@ -3275,6 +3289,22 @@ const inputClass = 'block w-full rounded-lg border border-zinc-300 bg-white px-3
                                     />
                                     <div v-else class="hidden sm:block" />
                                 </div>
+                            </div>
+                            <div>
+                                <label class="mb-1 block text-sm font-medium text-zinc-700 dark:text-zinc-300">Duração do acesso</label>
+                                <input
+                                    v-model="moduleModalAccessDurationDays"
+                                    type="number"
+                                    min="1"
+                                    max="3650"
+                                    step="1"
+                                    :class="inputClass"
+                                    class="w-full"
+                                    placeholder="Ilimitado"
+                                />
+                                <p class="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+                                    Em dias após a compra. Deixe vazio para acesso ilimitado.
+                                </p>
                             </div>
                             <div>
                                 <label class="mb-1 block text-sm font-medium text-zinc-700 dark:text-zinc-300">Capa — {{ moduleModalCoverMode === 'horizontal' ? 'banner' : 'vertical' }}</label>

--- a/resources/js/components/member-builder/MemberBuilderLessonEditor.vue
+++ b/resources/js/components/member-builder/MemberBuilderLessonEditor.vue
@@ -152,6 +152,21 @@ const lessonsModel = defineModel('lessons', { type: Array, default: () => [] });
                     />
                 </div>
             </div>
+            <div>
+                <label class="mb-1 block text-xs font-medium text-zinc-600 dark:text-zinc-400">Duração do acesso</label>
+                <input
+                    v-model="lessonForm.access_duration_days"
+                    type="number"
+                    min="1"
+                    max="3650"
+                    :class="inputClass"
+                    class="w-full"
+                    placeholder="Ilimitado"
+                />
+                <p class="mt-1 text-[10px] text-zinc-500 dark:text-zinc-400">
+                    Em dias após a compra. Deixe vazio para acesso ilimitado.
+                </p>
+            </div>
             <div v-if="lessonForm.type === 'link'">
                 <label class="mb-1 block text-xs font-medium text-zinc-600 dark:text-zinc-400">Título do link</label>
                 <input v-model="lessonForm.link_title" type="text" :class="inputClass" class="w-full" placeholder="Ex: Abrir material" />

--- a/resources/js/components/member-builder/MemberBuilderModuleEditor.vue
+++ b/resources/js/components/member-builder/MemberBuilderModuleEditor.vue
@@ -17,6 +17,7 @@ defineProps({
     editingReleaseMode: { type: String, default: 'none' },
     editingReleaseAfterDays: { type: String, default: '' },
     editingReleaseAtDate: { type: String, default: '' },
+    editingAccessDurationDays: { type: String, default: '' },
     editingThumbnail: { type: String, default: null },
     thumbnailUploading: { type: Boolean, default: false },
 });
@@ -30,6 +31,7 @@ const emit = defineEmits([
     'update:editingReleaseMode',
     'update:editingReleaseAfterDays',
     'update:editingReleaseAtDate',
+    'update:editingAccessDurationDays',
     'save',
     'pick-thumbnail',
     'remove-thumbnail',
@@ -129,6 +131,22 @@ const emit = defineEmits([
                         @input="emit('update:editingReleaseAtDate', $event.target.value)"
                     />
                 </div>
+            </div>
+            <div>
+                <label class="mb-1 block text-xs font-medium text-zinc-600 dark:text-zinc-400">Duração do acesso</label>
+                <input
+                    :value="editingAccessDurationDays"
+                    type="number"
+                    min="1"
+                    max="3650"
+                    :class="inputClass"
+                    class="w-full"
+                    placeholder="Ilimitado"
+                    @input="emit('update:editingAccessDurationDays', $event.target.value)"
+                />
+                <p class="mt-1 text-[10px] text-zinc-500 dark:text-zinc-400">
+                    Em dias após a compra. Deixe vazio para acesso ilimitado.
+                </p>
             </div>
         </template>
 

--- a/resources/js/components/member-builder/MemberBuilderModulesTab.vue
+++ b/resources/js/components/member-builder/MemberBuilderModulesTab.vue
@@ -37,6 +37,7 @@ const props = defineProps({
     editingModuleReleaseMode: { type: String, default: 'none' },
     editingModuleReleaseAfterDays: { type: String, default: '' },
     editingModuleReleaseAtDate: { type: String, default: '' },
+    editingModuleAccessDurationDays: { type: String, default: '' },
     editingModuleThumbnail: { type: String, default: null },
     moduleThumbnailUploading: { type: Boolean, default: false },
 });
@@ -82,6 +83,7 @@ const emit = defineEmits([
     'update:editingModuleReleaseMode',
     'update:editingModuleReleaseAfterDays',
     'update:editingModuleReleaseAtDate',
+    'update:editingModuleAccessDurationDays',
 ]);
 
 const mobileStep = ref('sections');
@@ -412,6 +414,7 @@ const columnClass = (step) => [
                         :editing-release-mode="editingModuleReleaseMode"
                         :editing-release-after-days="editingModuleReleaseAfterDays"
                         :editing-release-at-date="editingModuleReleaseAtDate"
+                        :editing-access-duration-days="editingModuleAccessDurationDays"
                         :editing-thumbnail="editingModuleThumbnail"
                         :thumbnail-uploading="moduleThumbnailUploading"
                         @update:editing-title="emit('update:editingModuleTitle', $event)"
@@ -422,6 +425,7 @@ const columnClass = (step) => [
                         @update:editing-release-mode="emit('update:editingModuleReleaseMode', $event)"
                         @update:editing-release-after-days="emit('update:editingModuleReleaseAfterDays', $event)"
                         @update:editing-release-at-date="emit('update:editingModuleReleaseAtDate', $event)"
+                        @update:editing-access-duration-days="emit('update:editingModuleAccessDurationDays', $event)"
                         @save="emit('save-module')"
                         @pick-thumbnail="emit('pick-module-thumbnail')"
                         @remove-thumbnail="emit('remove-module-thumbnail')"

--- a/tests/Feature/MemberContentDurationTest.php
+++ b/tests/Feature/MemberContentDurationTest.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Middleware\EnsureDockerSetup;
+use App\Http\Middleware\EnsureInstalled;
+use App\Models\MemberLesson;
+use App\Models\MemberModule;
+use App\Models\MemberSection;
+use App\Models\Product;
+use App\Models\User;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class MemberContentDurationTest extends TestCase
+{
+    public function test_builder_saves_access_duration_for_modules_and_lessons(): void
+    {
+        $this->withoutMiddleware([EnsureInstalled::class, EnsureDockerSetup::class]);
+
+        [$owner, $product, $section, $module] = $this->makeMemberContent();
+
+        $this->actingAs($owner)->putJson(
+            route('member-builder.modules.update', ['produto' => $product, 'module' => $module]),
+            ['access_duration_days' => 180],
+        )->assertOk();
+
+        $lessonResponse = $this->actingAs($owner)->postJson(
+            route('member-builder.lessons.store', ['produto' => $product, 'module' => $module]),
+            [
+                'title' => 'Aula temporária',
+                'type' => MemberLesson::TYPE_TEXT,
+                'content_text' => '<p>Conteúdo</p>',
+                'access_duration_days' => 365,
+            ],
+        );
+
+        $lessonResponse->assertOk();
+        $this->assertDatabaseHas('member_modules', [
+            'id' => $module->id,
+            'access_duration_days' => 180,
+        ]);
+        $this->assertDatabaseHas('member_lessons', [
+            'member_module_id' => $module->id,
+            'title' => 'Aula temporária',
+            'access_duration_days' => 365,
+        ]);
+    }
+
+    public function test_expired_module_is_locked_and_cannot_be_opened(): void
+    {
+        $this->withoutMiddleware([EnsureInstalled::class, EnsureDockerSetup::class]);
+        Carbon::setTestNow('2026-07-27 12:00:00');
+
+        [, $product, , $module] = $this->makeMemberContent([
+            'access_duration_days' => 30,
+        ]);
+        $lesson = $this->makeLesson($product, $module);
+        $student = $this->attachStudent($product, now()->subDays(31));
+
+        $this->actingAs($student)
+            ->get('/m/'.$product->checkout_slug)
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->where('sections.0.modules.0.is_locked', true)
+                ->where('sections.0.modules.0.lock_reason', 'expired')
+                ->where('sections.0.modules.0.lock_message', 'Acesso encerrado em 26/07/2026')
+            );
+
+        $this->actingAs($student)
+            ->get('/m/'.$product->checkout_slug.'/modulo/'.$module->id)
+            ->assertRedirect('/m/'.$product->checkout_slug.'/modulos');
+
+        $this->actingAs($student)
+            ->postJson('/m/'.$product->checkout_slug.'/aula/'.$lesson->id.'/complete')
+            ->assertForbidden();
+
+        $this->assertDatabaseMissing('member_lesson_progress', [
+            'member_lesson_id' => $lesson->id,
+            'user_id' => $student->id,
+        ]);
+    }
+
+    public function test_lesson_duration_expires_independently_from_its_module(): void
+    {
+        $this->withoutMiddleware([EnsureInstalled::class, EnsureDockerSetup::class]);
+        Carbon::setTestNow('2026-07-27 12:00:00');
+
+        [, $product, , $module] = $this->makeMemberContent();
+        $expiredLesson = $this->makeLesson($product, $module, [
+            'title' => 'Aula expirada',
+            'position' => 1,
+            'access_duration_days' => 30,
+        ]);
+        $availableLesson = $this->makeLesson($product, $module, [
+            'title' => 'Aula disponível',
+            'position' => 2,
+        ]);
+        $student = $this->attachStudent($product, now()->subDays(31));
+
+        $this->actingAs($student)
+            ->get('/m/'.$product->checkout_slug.'/modulo/'.$module->id.'?aula='.$expiredLesson->id)
+            ->assertRedirect('/m/'.$product->checkout_slug.'/modulo/'.$module->id.'?aula='.$availableLesson->id);
+
+        $this->actingAs($student)
+            ->get('/m/'.$product->checkout_slug.'/modulo/'.$module->id.'?aula='.$availableLesson->id)
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->where('lessons.0.is_locked', true)
+                ->where('lessons.0.lock_reason', 'expired')
+                ->where('lessons.1.is_locked', false)
+                ->where('current_lesson.id', $availableLesson->id)
+            );
+    }
+
+    public function test_content_remains_available_until_duration_ends(): void
+    {
+        $this->withoutMiddleware([EnsureInstalled::class, EnsureDockerSetup::class]);
+        Carbon::setTestNow('2026-07-27 12:00:00');
+
+        [, $product, , $module] = $this->makeMemberContent([
+            'access_duration_days' => 30,
+        ]);
+        $lesson = $this->makeLesson($product, $module);
+        $student = $this->attachStudent($product, now()->subDays(29));
+
+        $this->actingAs($student)
+            ->get('/m/'.$product->checkout_slug.'/modulo/'.$module->id.'?aula='.$lesson->id)
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->where('module.is_locked', false)
+                ->where('module.expires_at', fn ($value) => is_string($value) && $value !== '')
+                ->where('current_lesson.id', $lesson->id)
+            );
+    }
+
+    /**
+     * @param  array<string, mixed>  $moduleOverrides
+     * @return array{User, Product, MemberSection, MemberModule}
+     */
+    private function makeMemberContent(array $moduleOverrides = []): array
+    {
+        $owner = User::factory()->create([
+            'role' => User::ROLE_INFOPRODUTOR,
+            'tenant_id' => 1,
+        ]);
+        $product = $this->createTestProduct([
+            'type' => Product::TYPE_AREA_MEMBROS,
+            'checkout_slug' => 'duration'.substr(uniqid('', true), -8),
+        ]);
+        $section = MemberSection::create([
+            'product_id' => $product->id,
+            'title' => 'Curso',
+            'position' => 1,
+            'section_type' => 'courses',
+        ]);
+        $module = MemberModule::create(array_merge([
+            'member_section_id' => $section->id,
+            'product_id' => $product->id,
+            'title' => 'Módulo',
+            'position' => 1,
+        ], $moduleOverrides));
+
+        return [$owner, $product, $section, $module];
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function makeLesson(Product $product, MemberModule $module, array $overrides = []): MemberLesson
+    {
+        return MemberLesson::create(array_merge([
+            'member_module_id' => $module->id,
+            'product_id' => $product->id,
+            'title' => 'Aula',
+            'position' => 1,
+            'type' => MemberLesson::TYPE_TEXT,
+            'content_text' => '<p>Conteúdo</p>',
+        ], $overrides));
+    }
+
+    private function attachStudent(Product $product, Carbon $accessStartedAt): User
+    {
+        $student = User::factory()->create([
+            'role' => User::ROLE_ALUNO,
+            'tenant_id' => 1,
+        ]);
+        $product->users()->attach($student->id, [
+            'created_at' => $accessStartedAt,
+            'updated_at' => $accessStartedAt,
+        ]);
+
+        return $student;
+    }
+}


### PR DESCRIPTION
## Resumo

- adiciona duração de acesso por módulo e aula
- bloqueia conteúdos expirados no backend
- apresenta a data de encerramento ao aluno
- inclui migração e testes funcionais

## Validação

- 11 testes aprovados
- 139 assertions
- build frontend aprovado

Closes #48